### PR TITLE
Introduce side-aware command structure registry

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -223,6 +223,18 @@ class CfgFunctions
             class setNestedObject {};
         };
 
+        class Command {
+            file = QPATHTOFOLDER(functions\Command);
+            class createCommandStructure {};
+            class getCommandStructureForSide {};
+            class getCommanderForSide {};
+            class getEconomyForSide {};
+            class initCommandStructures {};
+            class setCommanderForSide {};
+            class sideToKey {};
+            class updateEconomyForSide {};
+        };
+
         class CREATE {
             file = QPATHTOFOLDER(functions\CREATE);
             class AAFroadPatrol {};

--- a/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
@@ -24,6 +24,7 @@ if (_resourcesFIAT < 0) then {_resourcesFIAT = 0};
 
 server setVariable ["hr",_hrT,true];
 server setVariable ["resourcesFIA",_resourcesFIAT,true];
+[teamPlayer, _hr, _resourcesFIA] call A3A_fnc_updateEconomyForSide;
 resourcesIsChanging = false;
 
 if (_silent) exitWith {};

--- a/A3A/addons/core/functions/Command/fn_createCommandStructure.sqf
+++ b/A3A/addons/core/functions/Command/fn_createCommandStructure.sqf
@@ -1,0 +1,25 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_side", sideUnknown, [sideUnknown, grpNull, objNull, "", 0]]
+];
+
+private _sideKey = [_side] call A3A_fnc_sideToKey;
+
+private _structure = createHashMap;
+_structure set ["sideKey", _sideKey];
+if (_side isEqualType sideUnknown) then {
+    _structure set ["side", _side];
+};
+_structure set ["commander", objNull];
+_structure set ["hqObjects", []];
+_structure set ["hqPosition", [0,0,0]];
+_structure set ["hqMarker", ""];
+_structure set ["resources", 0];
+_structure set ["hr", 0];
+_structure set ["storage", createHashMap];
+_structure set ["unlocks", createHashMap];
+_structure set ["logisticsQueue", []];
+_structure set ["metadata", createHashMap];
+
+_structure

--- a/A3A/addons/core/functions/Command/fn_getCommandStructureForSide.sqf
+++ b/A3A/addons/core/functions/Command/fn_getCommandStructureForSide.sqf
@@ -1,0 +1,20 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_side", teamPlayer, [sideUnknown, grpNull, objNull, "", 0]]
+];
+
+private _structures = missionNamespace getVariable ["A3A_commandStructures", objNull];
+if !(_structures isEqualType createHashMap) then {
+    _structures = call A3A_fnc_initCommandStructures;
+};
+
+private _key = [_side] call A3A_fnc_sideToKey;
+private _structure = _structures getOrDefault [_key, objNull];
+if !(_structure isEqualType createHashMap) then {
+    _structure = [_side] call A3A_fnc_createCommandStructure;
+    _structures set [_key, _structure];
+    missionNamespace setVariable ["A3A_commandStructures", _structures, true];
+};
+
+_structure

--- a/A3A/addons/core/functions/Command/fn_getCommanderForSide.sqf
+++ b/A3A/addons/core/functions/Command/fn_getCommanderForSide.sqf
@@ -1,0 +1,8 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_side", teamPlayer, [sideUnknown, grpNull, objNull, "", 0]]
+];
+
+private _structure = [_side] call A3A_fnc_getCommandStructureForSide;
+_structure getOrDefault ["commander", objNull]

--- a/A3A/addons/core/functions/Command/fn_getEconomyForSide.sqf
+++ b/A3A/addons/core/functions/Command/fn_getEconomyForSide.sqf
@@ -1,0 +1,32 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_side", teamPlayer, [sideUnknown, grpNull, objNull, "", 0]]
+];
+
+private _structures = missionNamespace getVariable ["A3A_commandStructures", objNull];
+if !(_structures isEqualType createHashMap) then {
+    _structures = call A3A_fnc_initCommandStructures;
+};
+
+private _key = [_side] call A3A_fnc_sideToKey;
+private _structure = _structures getOrDefault [_key, objNull];
+if !(_structure isEqualType createHashMap) then {
+    _structure = [_side] call A3A_fnc_createCommandStructure;
+    _structures set [_key, _structure];
+    missionNamespace setVariable ["A3A_commandStructures", _structures, true];
+};
+
+private _storage = _structure getOrDefault ["storage", createHashMap];
+if !(_storage isEqualType createHashMap) then {
+    _storage = createHashMap;
+    _structure set ["storage", _storage];
+    _structures set [_key, _structure];
+    missionNamespace setVariable ["A3A_commandStructures", _structures, true];
+};
+
+[
+    _structure getOrDefault ["hr", 0],
+    _structure getOrDefault ["resources", 0],
+    _storage
+]

--- a/A3A/addons/core/functions/Command/fn_initCommandStructures.sqf
+++ b/A3A/addons/core/functions/Command/fn_initCommandStructures.sqf
@@ -1,0 +1,30 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+private _existing = missionNamespace getVariable ["A3A_commandStructures", objNull];
+if (_existing isEqualType createHashMap) exitWith { _existing };
+
+private _structures = createHashMap;
+
+private _defaultSides = [
+    teamPlayer,
+    Occupants,
+    Invaders,
+    west,
+    east,
+    independent,
+    resistance,
+    civilian,
+    sideUnknown
+];
+
+{
+    private _key = [_x] call A3A_fnc_sideToKey;
+    if (!(_structures getOrDefault [_key, objNull] isEqualType createHashMap)) then {
+        _structures set [_key, [_x] call A3A_fnc_createCommandStructure];
+    };
+} forEach _defaultSides;
+
+missionNamespace setVariable ["A3A_commandStructures", _structures, true];
+
+_structures

--- a/A3A/addons/core/functions/Command/fn_setCommanderForSide.sqf
+++ b/A3A/addons/core/functions/Command/fn_setCommanderForSide.sqf
@@ -1,0 +1,30 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_side", teamPlayer, [sideUnknown, grpNull, objNull, "", 0]],
+    ["_commander", objNull, [objNull]]
+];
+
+if (!isServer) exitWith {
+    [_side, _commander] remoteExecCall ["A3A_fnc_setCommanderForSide", 2];
+};
+
+private _structures = missionNamespace getVariable ["A3A_commandStructures", objNull];
+if !(_structures isEqualType createHashMap) then {
+    _structures = call A3A_fnc_initCommandStructures;
+};
+
+private _key = [_side] call A3A_fnc_sideToKey;
+private _structure = _structures getOrDefault [_key, objNull];
+if !(_structure isEqualType createHashMap) then {
+    _structure = [_side] call A3A_fnc_createCommandStructure;
+};
+
+_structure set ["commander", _commander];
+if (_side isEqualType sideUnknown) then {
+    _structure set ["side", _side];
+};
+_structure set ["sideKey", _key];
+
+_structures set [_key, _structure];
+missionNamespace setVariable ["A3A_commandStructures", _structures, true];

--- a/A3A/addons/core/functions/Command/fn_sideToKey.sqf
+++ b/A3A/addons/core/functions/Command/fn_sideToKey.sqf
@@ -1,0 +1,69 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_input", sideUnknown, [sideUnknown, grpNull, objNull, "", 0]]
+];
+
+private _side = _input;
+
+switch (typeName _side) do {
+    case "GROUP": {
+        _side = if (isNull _side) then { sideUnknown } else { side _side };
+    };
+    case "OBJECT": {
+        if (isNull _side) then {
+            _side = sideUnknown;
+        } else {
+            _side = side group _side;
+        };
+    };
+    case "SCALAR": {
+        // Allow passing raw sideID values, mostly for debugging helpers.
+        private _sideFromId = [west, east, independent, civilian, resistance] select {_x call BIS_fnc_sideID == _side};
+        if (_sideFromId isNotEqualTo []) then {
+            _side = _sideFromId#0;
+        } else {
+            // Unknown scalar, just stringise it.
+            private _result = str _side;
+            _result = toLower _result;
+            _result = _result select [0, min [count _result, 64]];
+            _result = [_result, "unknown"] select (_result isEqualTo "");
+            return _result;
+        };
+    };
+    case "STRING": {
+        private _result = toLower _side;
+        switch (_result) do {
+            case "west": { _result = "west"; };
+            case "blu": { _result = "west"; };
+            case "blufor": { _result = "west"; };
+            case "east": { _result = "east"; };
+            case "opfor": { _result = "east"; };
+            case "independent": { _result = "guer"; };
+            case "indy": { _result = "guer"; };
+            case "guer": { _result = "guer"; };
+            case "resistance": { _result = "guer"; };
+            case "civilian": { _result = "civ"; };
+            case "civ": { _result = "civ"; };
+            default {
+                if (_result isEqualTo "") then { _result = "unknown"; };
+            };
+        };
+        return _result;
+    };
+};
+
+if (!(_side isEqualType sideUnknown)) exitWith {
+    // Fallback for unsupported types.
+    private _result = toLower str _side;
+    if (_result isEqualTo "") then { _result = "unknown"; };
+    _result
+};
+
+private _result = toLower str _side;
+if (_result isEqualTo "independent") then { _result = "guer"; };
+if (_result isEqualTo "resistance") then { _result = "guer"; };
+if (_result isEqualTo "civilian") then { _result = "civ"; };
+if (_result isEqualTo "") then { _result = "unknown"; };
+
+_result

--- a/A3A/addons/core/functions/Command/fn_updateEconomyForSide.sqf
+++ b/A3A/addons/core/functions/Command/fn_updateEconomyForSide.sqf
@@ -1,0 +1,56 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+params [
+    ["_side", teamPlayer, [sideUnknown, grpNull, objNull, "", 0]],
+    ["_hrChange", 0, [0]],
+    ["_resourceChange", 0, [0]],
+    ["_options", createHashMap, [createHashMap, []]]
+];
+
+private _optionsHM = _options;
+if !(_optionsHM isEqualType createHashMap) then {
+    _optionsHM = createHashMapFromArray _options;
+};
+
+private _mode = _optionsHM getOrDefault ["mode", "delta"];
+
+private _structures = missionNamespace getVariable ["A3A_commandStructures", objNull];
+if !(_structures isEqualType createHashMap) then {
+    _structures = call A3A_fnc_initCommandStructures;
+};
+
+private _key = [_side] call A3A_fnc_sideToKey;
+private _structure = _structures getOrDefault [_key, objNull];
+if !(_structure isEqualType createHashMap) then {
+    _structure = [_side] call A3A_fnc_createCommandStructure;
+    _structures set [_key, _structure];
+};
+
+private _currentHr = _structure getOrDefault ["hr", 0];
+private _currentResources = _structure getOrDefault ["resources", 0];
+
+switch (_mode) do {
+    case "set": {
+        _currentHr = _hrChange;
+        _currentResources = _resourceChange;
+    };
+    default {
+        _currentHr = _currentHr + _hrChange;
+        _currentResources = _currentResources + _resourceChange;
+    };
+};
+
+if (_currentHr < 0) then { _currentHr = 0; };
+if (_currentResources < 0) then { _currentResources = 0; };
+
+_structure set ["hr", _currentHr];
+_structure set ["resources", _currentResources];
+_structure set ["sideKey", _key];
+if (_side isEqualType sideUnknown) then {
+    _structure set ["side", _side];
+};
+
+_structures set [_key, _structure];
+missionNamespace setVariable ["A3A_commandStructures", _structures, true];
+
+[_currentHr, _currentResources]

--- a/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
@@ -16,9 +16,10 @@ if (!isNull theBoss) then
 
 theBoss = _newBoss;
 publicVariable "theBoss";
+[teamPlayer, _newBoss] call A3A_fnc_setCommanderForSide;
 
 if (isNull _newBoss) exitWith {
-	[_silent] spawn {
+        [_silent] spawn {
 		params ["_silent"];
 		sleep 5;
 		private _textX = format [localize "STR_A3A_fn_orgp_tBTransfer_noEligible"];

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -79,7 +79,11 @@ if (_varName in _specialVarLoads) then {
         aggressionStackInvaders = +(_varValue select 1);
         [true] spawn A3A_fnc_calculateAggression;
     };
-    if (_varName == 'hr') then {server setVariable ["HR",_varValue,true]};
+    if (_varName == 'hr') then {
+        server setVariable ["HR",_varValue,true];
+        private _economy = [teamPlayer] call A3A_fnc_getEconomyForSide;
+        [teamPlayer, _varValue, _economy#1, createHashMapFromArray [["mode", "set"]]] call A3A_fnc_updateEconomyForSide;
+    };
     if (_varName == 'dateX') then {setDate _varValue};
     if (_varName == 'weather') then {
         // Avoid persisting potentially-broken fog values
@@ -88,7 +92,11 @@ if (_varName in _specialVarLoads) then {
         0 setRain (_varValue select 1);
         forceWeatherChange
     };
-    if (_varName == 'resourcesFIA') then {server setVariable ["resourcesFIA",_varValue,true]};
+    if (_varName == 'resourcesFIA') then {
+        server setVariable ["resourcesFIA",_varValue,true];
+        private _economy = [teamPlayer] call A3A_fnc_getEconomyForSide;
+        [teamPlayer, _economy#0, _varValue, createHashMapFromArray [["mode", "set"]]] call A3A_fnc_updateEconomyForSide;
+    };
     if (_varName == 'destroyedSites') then {destroyedSites = +_varValue; publicVariable "destroyedSites"};
     if (_varName == 'skillFIA') then {
         skillFIA = _varValue; publicVariable "skillFIA";

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -34,6 +34,8 @@ colorTeamPlayer = "colorGUER";
 respawnTeamPlayer = "respawn_guerrila";			// not really sure why we have two markers here (also "Synd_HQ")
 posHQ = getMarkerPos respawnTeamPlayer;
 
+call A3A_fnc_initCommandStructures;
+
 ////////////////////////////////////////
 //     DECLARING PATCOM VARIABLES    ///
 ////////////////////////////////////////

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -94,6 +94,7 @@ DECLARE_SERVER_VAR(haveRadio, false);
 server setVariable ["hr",initialHr,true];
 //Initial faction money pool
 server setVariable ["resourcesFIA",initialFactionMoney,true];
+[teamPlayer, initialHr, initialFactionMoney, createHashMapFromArray [["mode", "set"]]] call A3A_fnc_updateEconomyForSide;
 // Time of last garbage clean. Note: serverTime may not reset to zero if server was not restarted. Therefore, it should capture the time at start of mission.
 DECLARE_SERVER_VAR(A3A_lastGarbageCleanTime, serverTime);
 // Hash map of custom non-member/AI item thresholds
@@ -183,6 +184,7 @@ hcArray = [];					// array of headless client IDs
 
 membersX = [];					// These two published later by startGame
 theBoss = objNull;
+[teamPlayer, objNull] call A3A_fnc_setCommanderForSide;
 
 createHashMap call A3A_fnc_setRebelLoadouts;		// sets version times, no dependencies
 


### PR DESCRIPTION
## Summary
- add a reusable command-structure module that tracks commanders, HQ data, and economy per side
- initialise the new registry during startup and keep it synchronised with existing commander and resource flows
- expose helpers for legacy logic to read or update commander/economy information in preparation for civil war mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b751040c832fb12c39157a3bcae0