### PR TITLE
Fix side key conversion exits

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -216,6 +216,11 @@ class CfgFunctions
             class processBuildingTimeouts {};
         };
 
+        class Command {
+            file = QPATHTOFOLDER(functions\Command);
+            class sideToKey {};
+        };
+
         class Collections {
             file = QPATHTOFOLDER(functions\Collections);
             class getNestedObject {};

--- a/A3A/addons/core/functions/Command/fn_sideToKey.sqf
+++ b/A3A/addons/core/functions/Command/fn_sideToKey.sqf
@@ -1,0 +1,55 @@
+/*
+Author: ChatGPT
+Description:
+    Converts various input types to the Antistasi faction key format.
+
+Arguments:
+0. <ANY> Supported types are SIDE, GROUP, OBJECT, STRING and SCALAR.
+
+Return Value:
+<STRING> Lowercase faction key (occ, inv, reb, civ, all) when recognised, otherwise an empty string.
+*/
+#include "..\..\script_component.hpp"
+params ["_value"];
+
+switch (typeName _value) do {
+    case "SCALAR": {
+        private _keys = ["occ", "inv", "reb", "civ", "all"];
+        if (_value < 0 || {_value >= count _keys}) exitWith { "" };
+        exitWith { _keys select _value };
+    };
+    case "STRING": {
+        exitWith { toLower _value };
+    };
+    case "SIDE": {
+        private _sideLookup = createHashMapFromArray [
+            [teamPlayer, "reb"],
+            [resistance, "reb"],
+            [Occupants, "occ"],
+            [west, "occ"],
+            [Invaders, "inv"],
+            [east, "inv"],
+            [civilian, "civ"],
+            [sideLogic, "logic"],
+            [sideEnemy, "enemy"],
+            [sideFriendly, "friendly"],
+            [sideAmbientLife, "ambient"],
+            [sideEmpty, "empty"],
+            [sideUnknown, ""]
+        ];
+        exitWith { _sideLookup getOrDefault [_value, toLower str _value] };
+    };
+    case "GROUP": {
+        if (isNull _value) exitWith { "" };
+        exitWith { [side _value] call A3A_fnc_sideToKey };
+    };
+    case "OBJECT": {
+        if (isNull _value) exitWith { "" };
+        private _side = if (_value isKindOf "Man") then { side group _value } else { side _value };
+        exitWith { [_side] call A3A_fnc_sideToKey };
+    };
+    default {
+        exitWith { "" };
+    };
+};
+""


### PR DESCRIPTION
## Summary
- register the Command function namespace so sideToKey is exposed
- ensure the new sideToKey implementation exits via `exitWith { ... }` for scalar, string, side, group, and object inputs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2bf6ea204832f9ee821c7683c5b04