### PR TITLE
Refactor FIA resource handling for multi-side economies

### DIFF
--- a/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
@@ -1,46 +1,95 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params [["_hr",""],["_resourcesFIA",""],["_silent",false]]; // nil protection
 
-if !(_hr isEqualType 0) exitWith {Error("The first parameter, the added HR, must be a number");};
-if !(_resourcesFIA isEqualType 0) exitWith {Error("The second parameter, the added money, must be a number");};
-waitUntil {!resourcesIsChanging};
-resourcesIsChanging = true;
+/*
+ * Extends the legacy FIA resource handler with side-aware economy support.
+ * Arguments:
+ * 0: HR delta <NUMBER>
+ * 1: Resource delta <NUMBER>
+ * 2: Silent update <BOOL> (optional)
+ * 3: Target side <ANY> (optional, default teamPlayer)
+ * 4: Propagate to clients <BOOL> (optional, default true)
+ */
 
-if ((floor _resourcesFIA == 0) and (floor _hr == 0)) exitWith {resourcesIsChanging = false};
-private _hrT = server getVariable "hr";
-private _resourcesFIAT = server getVariable "resourcesFIA";
+params [
+    ["_hrDelta", "", [0, ""]],
+    ["_resourceDelta", "", [0, ""]],
+    ["_silent", false, [false]],
+    ["_side", teamPlayer],
+    ["_propagate", true, [false]]
+];
 
-_hrT = _hrT + _hr;
-_resourcesFIAT = round (_resourcesFIAT + _resourcesFIA);
+if !(_hrDelta isEqualType 0) exitWith { Error("The first parameter, the added HR, must be a number"); };
+if !(_resourceDelta isEqualType 0) exitWith { Error("The second parameter, the added money, must be a number"); };
 
-if (_hrT < 0) then {
-	// If we're using more HR than we have (eg. player respawn at 0 HR) then hurt nearby city support
-	private _nearCity = citiesX select selectRandom (citiesX inAreaArrayIndexes [markerPos "Synd_HQ", distanceMission, distanceMission]);
-	[_hrT, _nearCity] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	_hrT = 0;
+private _sideKey = [_side] call A3A_fnc_sideToKey;
+if (_sideKey isEqualTo "") then {
+    Warning_1("Unrecognised side %1 passed to resourcesFIA, defaulting to rebel side", _side);
+    _side = teamPlayer;
+    _sideKey = "reb";
 };
-if (_resourcesFIAT < 0) then {_resourcesFIAT = 0};
 
-server setVariable ["hr",_hrT,true];
-server setVariable ["resourcesFIA",_resourcesFIAT,true];
-resourcesIsChanging = false;
+private _isRebel = _sideKey isEqualTo "reb";
+private _lockVarName = format ["A3A_resourcesLock_%1", _sideKey];
 
-if (_silent) exitWith {};
+if (_isRebel) then {
+    waitUntil {!resourcesIsChanging};
+    resourcesIsChanging = true;
+} else {
+    waitUntil {!(missionNamespace getVariable [_lockVarName, false])};
+    missionNamespace setVariable [_lockVarName, true];
+};
 
-_textX = "";
-_hrSim = "";
-if (_hr > 0) then {_hrSim = "+"};
-_resourcesFIASim = "";
-if (_resourcesFIA > 0) then {_resourcesFIASim = "+"};
+private _releaseLock = {
+    params ["_lockName", "_useRebelLock"];
+    if (_useRebelLock) then {
+        resourcesIsChanging = false;
+    } else {
+        missionNamespace setVariable [_lockName, false];
+    };
+};
 
-_faction = format ["<t size='0.6' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_resources" + "<br/><br/> ", FactionGet(reb,"name")];
-_hr = if (floor _hr == 0) then {""} else {format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_hr" + "</t><br/>", _hrSim, _hr toFixed 0];};
-_money = if (floor _resourcesFIA == 0) then {""} else {format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_money" + "</t>", _resourcesFIASim, _resourcesFIA toFixed 0];};
-_textX = _faction + _hr + _money;
+private _economy = [_side, true] call A3A_fnc_getEconomyForSide;
+private _currentHr = _economy getOrDefault ["hr", 0];
+private _currentResources = _economy getOrDefault ["resources", 0];
 
-if (_textX != "") then
-	{
-	[petros,"income",_textX] remoteExec ["A3A_fnc_commsMP",theBoss];
-	//[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];
-	};
+if ((floor _resourceDelta == 0) && {floor _hrDelta == 0}) exitWith {
+    [_lockVarName, _isRebel] call _releaseLock;
+    [_currentResources, _currentHr]
+};
+
+private _newHr = _currentHr + _hrDelta;
+private _newResources = round (_currentResources + _resourceDelta);
+
+if (_isRebel && {_newHr < 0}) then {
+    // If we're using more HR than we have (eg. player respawn at 0 HR) then hurt nearby city support.
+    private _nearCity = citiesX select selectRandom (citiesX inAreaArrayIndexes [markerPos "Synd_HQ", distanceMission, distanceMission]);
+    [_newHr, _nearCity] remoteExecCall ["A3A_fnc_citySupportChange", 2];
+    _newHr = 0;
+};
+
+if (_newResources < 0) then { _newResources = 0; };
+private _hrDeltaApplied = _newHr - _currentHr;
+private _resourceDeltaApplied = _newResources - _currentResources;
+
+private _result = [_side, _resourceDeltaApplied, _hrDeltaApplied, _propagate] call A3A_fnc_updateEconomyForSide;
+[_lockVarName, _isRebel] call _releaseLock;
+
+if (_silent || {!_isRebel}) exitWith { _result };
+
+private _textX = "";
+private _hrSign = "";
+if (_hrDelta > 0) then { _hrSign = "+"; };
+private _resourceSign = "";
+if (_resourceDelta > 0) then { _resourceSign = "+"; };
+
+private _faction = format ["<t size='0.6' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_resources" + "<br/><br/> ", FactionGet(reb,"name")];
+private _hrText = if (floor _hrDelta == 0) then {""} else {format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_hr" + "</t><br/>", _hrSign, _hrDelta toFixed 0];};
+private _moneyText = if (floor _resourceDelta == 0) then {""} else {format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_money" + "</t>", _resourceSign, _resourceDelta toFixed 0];};
+_textX = _faction + _hrText + _moneyText;
+
+if (_textX != "") then {
+    [petros, "income", _textX] remoteExec ["A3A_fnc_commsMP", theBoss];
+};
+
+_result

--- a/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
@@ -17,6 +17,8 @@ if (!isNull theBoss) then
 theBoss = _newBoss;
 publicVariable "theBoss";
 
+[teamPlayer, _newBoss, true] call A3A_fnc_setCommanderForSide;
+
 if (isNull _newBoss) exitWith {
 	[_silent] spawn {
 		params ["_silent"];


### PR DESCRIPTION
## Summary
- extend the FIA resource handler to support side-aware command structures and optional side selection
- ensure boss transfers update the commander registry so the new data model stays in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e31e1b6e78832facbeefca27abdb5b