### PR TITLE
Refactor economy handling to side-aware helpers

### DIFF
--- a/A3A/addons/core/functions/AI/fn_captureX.sqf
+++ b/A3A/addons/core/functions/AI/fn_captureX.sqf
@@ -61,7 +61,7 @@ sleep 100;
 if (alive _unit && {!(_unit getVariable ["incapacitated", false])}) then
 {
 	([_sideX] + _modAggro) remoteExec ["A3A_fnc_addAggression",2];
-	if (_modHR) then { [1,0] remoteExec ["A3A_fnc_resourcesFIA",2] };
+        if (_modHR) then { [_fleeSide, 1, 0] remoteExec ["A3A_fnc_resourcesFIA",2] };
 };
 
 // If they escaped or were downed then record in the garrison. Deaths should already be recorded

--- a/A3A/addons/core/functions/AI/fn_mineSweep.sqf
+++ b/A3A/addons/core/functions/AI/fn_mineSweep.sqf
@@ -8,7 +8,7 @@ private _typeExp = FactionGet(reb,"unitExp");
 private _typeVeh = (FactionGet(reb,"vehiclesLightUnarmed")) # 0;
 _costs = (server getVariable _typeExp) + ([_typeVeh] call A3A_fnc_vehiclePrice);
 
-[-1,-1*_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+[teamPlayer, -1, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 
 _groupX = createGroup teamPlayer;
 

--- a/A3A/addons/core/functions/AI/fn_rebelReturnToBase.sqf
+++ b/A3A/addons/core/functions/AI/fn_rebelReturnToBase.sqf
@@ -59,8 +59,9 @@ ServerDebug_1("Group %1 escaping to rebel territory", _group);
     sleep 120;          // give them a couple of minutes to run
 
     // Some slightly generous refunding. Probably shouldn't bother
-    private _refundHR = 0;
-    private _refundCash = 0;
+private _refundHR = 0;
+private _refundCash = 0;
+private _side = side _group;
     {
         if (!alive _x) then { continue };
         if (_x getVariable ["incapacitated", false]) then { _x setDamage 1; continue };
@@ -72,5 +73,5 @@ ServerDebug_1("Group %1 escaping to rebel territory", _group);
     } forEach units _group;
 
     deleteGroup _group;
-    [_refundHR, _refundCash] remoteExec ["A3A_fnc_resourcesFIA", 2];
+    [_side, _refundHR, _refundCash] remoteExec ["A3A_fnc_resourcesFIA", 2];
 };

--- a/A3A/addons/core/functions/Ammunition/fn_ammunitionTransfer.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_ammunitionTransfer.sqf
@@ -180,7 +180,7 @@ if (_destinationX == boxX) then
     private _arsenalText = "";
     if (_refund > 0) then
     {
-        [0,_refund, true] spawn A3A_fnc_resourcesFIA; 
+        [teamPlayer, 0, _refund, true] spawn A3A_fnc_resourcesFIA;
         _moneyText = format ["<t size='0.6' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_resources" + "<br/><br/></t>", FactionGet(reb,"name")]; 
         _moneyText = _moneyText + format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_money" + "</t><br/><br/><br/>","+", _refund];
     };

--- a/A3A/addons/core/functions/Base/fn_citySideChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_citySideChange.sqf
@@ -15,7 +15,7 @@ if (_rebel) then {
 	if (_forceSupport >= 0) then { _cityData set [1, _forceSupport max _cityData#1] };
 	sidesX setVariable [_city, teamPlayer, true];
 	[Occupants, 10, 60] spawn A3A_fnc_addAggression;
-	[_cityData#2 max 0, 0] spawn A3A_fnc_resourcesFIA;
+        [teamPlayer, _cityData#2 max 0, 0] spawn A3A_fnc_resourcesFIA;
 	[_city, teamPlayer] call A3A_fnc_garrisonServer_changeSide;
 	//[_city] call A3A_fnc_deleteNearSites;
 } else {

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -45,9 +45,10 @@ petros addMPEventHandler ["mpkilled",
     if ((side _killer == Invaders) or (side _killer == Occupants) or petros getVariable ["A3A_napalmHit", false]) then
     {
         garrison setVariable ["Synd_HQ", [], true];
-        _hr = server getVariable "hr";
-        _res = server getVariable "resourcesFIA";
-        [-1*(round(_hr*0.9)), -1*(round(_res*0.9))] spawn A3A_fnc_resourcesFIA;
+        private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+        _hr = _economy getOrDefault ["hr", 0];
+        _res = _economy getOrDefault ["resources", 0];
+        [teamPlayer, -1*(round(_hr*0.9)), -1*(round(_res*0.9))] spawn A3A_fnc_resourcesFIA;
         A3A_petrosMoving = false; publicVariable "A3A_petrosMoving";
         [] spawn A3A_fnc_petrosDeathMonitor;
     }

--- a/A3A/addons/core/functions/Base/fn_logPerformance.sqf
+++ b/A3A/addons/core/functions/Base/fn_logPerformance.sqf
@@ -7,6 +7,10 @@ private _countInvaders = 0;
 private _countOccupants = 0;
 private _countCiv = 0;
 
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _resourcesValue = _economy getOrDefault ["resources", 0];
+private _hrValue = _economy getOrDefault ["hr", 0];
+
 {
 	_countGroups = _countGroups + 1;
 	switch(side _x) do {
@@ -46,8 +50,8 @@ private _performanceLog = format [
 	,count entities ""
 	,{!isPlayer _x && !isNull (_x findNearestEnemy _x)} count allUnits
 	,{behaviour leader _x == "COMBAT"} count allGroups
-	,(server getVariable "resourcesFIA") toFixed 0
-	,(server getVariable "hr") toFixed 0
+        ,_resourcesValue toFixed 0
+        ,_hrValue toFixed 0
     ,aggressionOccupants
     ,aggressionInvaders
     ,tierWar

--- a/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
+++ b/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
@@ -55,14 +55,15 @@ else
 	};
 //if ((_typeX == "delete") and (_positionTel distance _pos >10)) exitWith {hint "No post nearby"};
 
-_resourcesFIA = server getVariable "resourcesFIA";
-_hrFIA = server getVariable "hr";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+_resourcesFIA = _economy getOrDefault ["resources", 0];
+_hrFIA = _economy getOrDefault ["hr", 0];
 
 if (((_resourcesFIA < _costs) or (_hrFIA < _hr)) and (_typeX!= "delete")) exitWith {[_titleStr, format [localize "STR_A3A_fn_base_outpdiag_no_resources",_hr,_costs]] call A3A_fnc_customHint;};
 
 if (_typeX != "delete") then
 	{
-	[-_hr,-_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+        [teamPlayer, -_hr, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 	};
 
  [_typeX,_positionTel] remoteExec ["A3A_fnc_createOutpostsFIA", 2];

--- a/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
@@ -5,7 +5,8 @@ params [["_siteX", "", [""]]];
 
 private _titleStr = localize "STR_A3A_fn_base_rebasset_title";
 
-private _resourcesFIA = server getVariable "resourcesFIA";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _resourcesFIA = _economy getOrDefault ["resources", 0];
 if (_resourcesFIA < 5000) exitWith {[_titleStr, localize "STR_A3A_fn_base_rebasset_no_money"] call A3A_fnc_customHint;};
 
 private _shouldGetLocation = (_siteX isEqualTo "");  // If no location given, default behavior. New UI provides location.
@@ -38,14 +39,14 @@ if (_siteX in _destroyedSites) exitWith {
     [Invaders, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
     destroyedSites = destroyedSites - [_siteX];
     publicVariable "destroyedSites";
-    [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, 0, -5000] remoteExec ["A3A_fnc_resourcesFIA",2];
 };
 
 private _radioTowers = antennasDead select {_x inArea _siteX};
 if (_radioTowers isNotEqualTo []) exitWith {
     [_titleStr, localize "STR_A3A_fn_base_rebasset_done_2"] call A3A_fnc_customHint;
     [_radioTowers#0] remoteExec ["A3A_fnc_rebuildRadioTower", 2];
-    [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, 0, -5000] remoteExec ["A3A_fnc_resourcesFIA",2];
 };
 
 [_titleStr, localize "STR_A3A_fn_base_rebasset_no_nothing"] call A3A_fnc_customHint;

--- a/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
@@ -1,46 +1,98 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params [["_hr",""],["_resourcesFIA",""],["_silent",false]]; // nil protection
 
-if !(_hr isEqualType 0) exitWith {Error("The first parameter, the added HR, must be a number");};
-if !(_resourcesFIA isEqualType 0) exitWith {Error("The second parameter, the added money, must be a number");};
-waitUntil {!resourcesIsChanging};
+private _sideInput = teamPlayer;
+private _hrDelta = 0;
+private _resourceDelta = 0;
+private _silent = false;
+
+// Maintain backwards compatibility with pre-refactor parameter order
+private _args = _this;
+if (!(_args isEqualType [])) then { _args = [_args]; };
+
+if ((count _args) > 0 && {(_args#0) isEqualType 0}) then {
+    _hrDelta = _args#0;
+    if ((count _args) > 1 && {(_args#1) isEqualType 0}) then { _resourceDelta = _args#1; };
+    if ((count _args) > 2 && {(_args#2) isEqualType true}) then { _silent = _args#2; };
+} else {
+    if ((count _args) > 0) then { _sideInput = _args#0; };
+    if ((count _args) > 1) then { _hrDelta = _args#1; };
+    if ((count _args) > 2) then { _resourceDelta = _args#2; };
+    if ((count _args) > 3) then { _silent = _args#3; };
+};
+
+if !(_hrDelta isEqualType 0) exitWith { Error("The added HR must be a number"); };
+if !(_resourceDelta isEqualType 0) exitWith { Error("The added money must be a number"); };
+if !(_silent isEqualType true) then { _silent = false; };
+
+waitUntil { !resourcesIsChanging };
 resourcesIsChanging = true;
 
-if ((floor _resourcesFIA == 0) and (floor _hr == 0)) exitWith {resourcesIsChanging = false};
-private _hrT = server getVariable "hr";
-private _resourcesFIAT = server getVariable "resourcesFIA";
+if ((floor _resourceDelta == 0) && {floor _hrDelta == 0}) exitWith { resourcesIsChanging = false };
 
-_hrT = _hrT + _hr;
-_resourcesFIAT = round (_resourcesFIAT + _resourcesFIA);
+private _economy = [_sideInput, true] call A3A_fnc_getEconomyForSide;
+private _currentResources = _economy getOrDefault ["resources", 0];
+private _currentHr = _economy getOrDefault ["hr", 0];
 
-if (_hrT < 0) then {
-	// If we're using more HR than we have (eg. player respawn at 0 HR) then hurt nearby city support
-	private _nearCity = citiesX select selectRandom (citiesX inAreaArrayIndexes [markerPos "Synd_HQ", distanceMission, distanceMission]);
-	[_hrT, _nearCity] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	_hrT = 0;
+private _sideKey = [_sideInput] call A3A_fnc_sideToKey;
+private _pendingHr = _currentHr + _hrDelta;
+
+if ((_pendingHr < 0) && {_sideKey isEqualTo "reb"}) then {
+    private _structure = [_sideInput, false] call A3A_fnc_getCommandStructureForSide;
+    private _hqMarker = "Synd_HQ";
+    if (_structure isEqualType createHashMap) then {
+        _hqMarker = _structure getOrDefault ["hqMarker", _hqMarker];
+    };
+
+    private _hqPos = markerPos _hqMarker;
+    private _cityIndexes = citiesX inAreaArrayIndexes [_hqPos, distanceMission, distanceMission];
+    if (_cityIndexes isNotEqualTo []) then {
+        private _nearCity = citiesX select selectRandom _cityIndexes;
+        [_pendingHr, _nearCity] remoteExecCall ["A3A_fnc_citySupportChange", 2];
+    };
 };
-if (_resourcesFIAT < 0) then {_resourcesFIAT = 0};
 
-server setVariable ["hr",_hrT,true];
-server setVariable ["resourcesFIA",_resourcesFIAT,true];
+[_sideInput, _resourceDelta, _hrDelta] call A3A_fnc_updateEconomyForSide;
+
 resourcesIsChanging = false;
 
 if (_silent) exitWith {};
 
-_textX = "";
-_hrSim = "";
-if (_hr > 0) then {_hrSim = "+"};
-_resourcesFIASim = "";
-if (_resourcesFIA > 0) then {_resourcesFIASim = "+"};
+private _factionName = switch (_sideKey) do {
+    case "occ": { FactionGet(occ,"name") };
+    case "inv": { FactionGet(inv,"name") };
+    case "civ": { FactionGet(civ,"name") };
+    default { FactionGet(reb,"name") };
+};
 
-_faction = format ["<t size='0.6' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_resources" + "<br/><br/> ", FactionGet(reb,"name")];
-_hr = if (floor _hr == 0) then {""} else {format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_hr" + "</t><br/>", _hrSim, _hr toFixed 0];};
-_money = if (floor _resourcesFIA == 0) then {""} else {format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_money" + "</t>", _resourcesFIASim, _resourcesFIA toFixed 0];};
-_textX = _faction + _hr + _money;
+private _hrSim = if (_hrDelta > 0) then {"+"} else {""};
+private _resSim = if (_resourceDelta > 0) then {"+"} else {""};
 
-if (_textX != "") then
-	{
-	[petros,"income",_textX] remoteExec ["A3A_fnc_commsMP",theBoss];
-	//[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];
-	};
+private _hrText = if (floor _hrDelta == 0) then {
+    ""
+} else {
+    format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_hr" + "</t><br/>", _hrSim, _hrDelta toFixed 0]
+};
+
+private _moneyText = if (floor _resourceDelta == 0) then {
+    ""
+} else {
+    format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_money" + "</t>", _resSim, _resourceDelta toFixed 0]
+};
+
+private _textX = format ["<t size='0.6' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_resources" + "<br/><br/> ", _factionName] + _hrText + _moneyText;
+
+if (_textX isEqualTo "") exitWith {};
+
+private _commanderUnit = [_sideInput] call A3A_fnc_getCommanderForSide;
+private _speaker = _commanderUnit;
+private _target = _commanderUnit;
+
+if (isNull _commanderUnit && {_sideKey isEqualTo "reb"}) then {
+    _speaker = petros;
+    _target = theBoss;
+};
+
+if (!isNull _speaker && {!isNull _target}) then {
+    [_speaker, "income", _textX] remoteExec ["A3A_fnc_commsMP", _target];
+};

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -62,7 +62,7 @@ if (_costs == 0) exitWith {
 
 _costs = round (_costs * (1-damage _veh));
 
-[0,_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+[teamPlayer, 0, _costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 
 private _vehMarker = _veh getVariable "markerX";
 if (!isNil "_vehMarker") then { [_veh] call A3A_fnc_garrisonServer_remVehicle };

--- a/A3A/addons/core/functions/Base/fn_statistics.sqf
+++ b/A3A/addons/core/functions/Base/fn_statistics.sqf
@@ -19,14 +19,18 @@ private _player = player getVariable ["owner",player];		// different, if remote-
 private _ucovertxt = ["Off", "<t color='#1DA81D'>On</t>"] select ((captive _player) and !(_player getVariable ["incapacitated",false]));
 if (_player getVariable ["isAFK", false]) then { _ucovertxt = _ucovertxt + " | <t color='#A81D1D'>AFK</t>" };
 
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _hrValue = _economy getOrDefault ["hr", 0];
+private _resourcesValue = _economy getOrDefault ["resources", 0];
+
 if (_player != theBoss) then
 	{
 	private _nameC = if !(isNull theBoss) then {name theBoss} else {"None"};
-	_textX = format ["<t size='0.67' shadow='2'>" + localize "STR_A3A_fn_base_statistics_notComm", (server getVariable "hr") toFixed 0, rank _player, _nameC, (_player getVariable "moneyX") toFixed 0,[aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),_ucovertxt];
+	_textX = format ["<t size='0.67' shadow='2'>" + localize "STR_A3A_fn_base_statistics_notComm", _hrValue toFixed 0, rank _player, _nameC, (_player getVariable "moneyX") toFixed 0,[aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),_ucovertxt];
 	}
 else
 	{
-	_textX = format ["<t size='0.67' shadow='2'>" + localize "STR_A3A_fn_base_statistics_isComm", (server getVariable "hr") toFixed 0, (server getVariable "resourcesFIA") toFixed 0, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, (_player getVariable "moneyX") toFixed 0,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
+	_textX = format ["<t size='0.67' shadow='2'>" + localize "STR_A3A_fn_base_statistics_isComm", _hrValue toFixed 0, _resourcesValue toFixed 0, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, (_player getVariable "moneyX") toFixed 0,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
 	};
 
 //if (captive player) then {_textX = format ["%1 ON",_textX]} else {_textX = format ["%1 OFF",_textX]};

--- a/A3A/addons/core/functions/Builder/fn_buildingComplete.sqf
+++ b/A3A/addons/core/functions/Builder/fn_buildingComplete.sqf
@@ -19,7 +19,7 @@ deleteVehicle _target;
 // Cancel case
 if (!_finished) exitWith {
     private _price = _target getVariable ["A3A_build_price", 10];
-    if (_price > 0) then { [0, _price] spawn A3A_fnc_resourcesFIA };
+    if (_price > 0) then { [teamPlayer, 0, _price] spawn A3A_fnc_resourcesFIA };
 };
 
 // Repair case, just call the repair function

--- a/A3A/addons/core/functions/Builder/fn_processBuildingTimeouts.sqf
+++ b/A3A/addons/core/functions/Builder/fn_processBuildingTimeouts.sqf
@@ -18,7 +18,7 @@ isNil {
 
         // refund? Arguable
         private _price = _object getVariable ["A3A_build_price", 0];
-        if (_price >= 0) then { [0, _price] spawn A3A_fnc_resourcesFIA; };
+        if (_price >= 0) then { [teamPlayer, 0, _price] spawn A3A_fnc_resourcesFIA; };
 
         // remove the object from the list
         A3A_unbuiltObjects deleteAt _forEachIndex;

--- a/A3A/addons/core/functions/Dialogs/fn_mineDialog.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_mineDialog.sqf
@@ -15,11 +15,14 @@ _typeX = _this select 0;
 _costs = 2*(server getVariable FactionGet(reb,"unitExp")) + ([(FactionGet(reb,"vehiclesTruck")) # 0] call A3A_fnc_vehiclePrice);
 _hr = 2;
 if (_typeX == "delete") then
-	{
-	_costs = _costs - (server getVariable FactionGet(reb,"unitExp"));
-	_hr = 1;
-	};
-if ((server getVariable "resourcesFIA" < _costs) or (server getVariable "hr" < _hr)) exitWith {[_titleStr, format [localize "STR_A3A_fn_dialogs_minediag_no_resource",_costs,_hr]] call A3A_fnc_customHint;};
+        {
+        _costs = _costs - (server getVariable FactionGet(reb,"unitExp"));
+        _hr = 1;
+        };
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _resourcesFIA = _economy getOrDefault ["resources", 0];
+private _hrAvailable = _economy getOrDefault ["hr", 0];
+if ((_resourcesFIA < _costs) or (_hrAvailable < _hr)) exitWith {[_titleStr, format [localize "STR_A3A_fn_dialogs_minediag_no_resource",_costs,_hr]] call A3A_fnc_customHint;};
 
 if (_typeX == "delete") exitWith
 	{

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_addUnitType.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_addUnitType.sqf
@@ -27,12 +27,13 @@ if (sidesX getVariable [_marker, sideUnknown] != teamPlayer) exitWith {
 	[_titleStr, format [localize "STR_A3A_fn_reinf_garrDia_zone_belong",FactionGet(reb,"name")]] remoteExecCall ["A3A_fnc_customHint", _client];
 };
 
-private _hr = server getVariable "hr";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _hr = _economy getOrDefault ["hr", 0];
 if (_hr < 1) exitWith {
-	[_titleStr, localize "STR_A3A_garrison_error_no_hr"] remoteExecCall ["A3A_fnc_customHint", _client];
+        [_titleStr, localize "STR_A3A_garrison_error_no_hr"] remoteExecCall ["A3A_fnc_customHint", _client];
 };
 
-private _resourcesFIA = server getVariable "resourcesFIA";
+private _resourcesFIA = _economy getOrDefault ["resources", 0];
 private _costs = server getVariable _unitType;
 if (_costs > _resourcesFIA) exitWith {
 	[_titleStr,  format [localize "STR_A3A_garrison_error_no_money", _costs]] remoteExecCall ["A3A_fnc_customHint", _client];
@@ -50,7 +51,7 @@ if (_limit != -1 && {count _troops >= _limit}) exitWith {
 };
 
 // ugh
-[-1,-_costs] spawn A3A_fnc_resourcesFIA;
+[teamPlayer, -1, -_costs] spawn A3A_fnc_resourcesFIA;
 
 // Add unit to server garrison data
 _troops pushBack _unitType;

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_clear.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_clear.sqf
@@ -83,7 +83,7 @@ if (_hqMove) then {
 
 private _safe = !(_marker call A3A_fnc_enemyNearCheck);
 if (_safe) then {
-    [_hr, _costs] spawn A3A_fnc_resourcesFIA;        // TODO: should turn this thing into unscheduled
+    [teamPlayer, _hr, _costs] spawn A3A_fnc_resourcesFIA;        // TODO: should turn this thing into unscheduled
 };
 
 if (_marker in A3A_garrisonMachine) then {

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_remUnitType.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_remUnitType.sqf
@@ -40,7 +40,7 @@ if (_troops find _unitType == -1) exitWith {
 };
 
 // ugh
-[1, (server getVariable [_unitType, 0]) / 2] spawn A3A_fnc_resourcesFIA;
+[teamPlayer, 1, (server getVariable [_unitType, 0]) / 2] spawn A3A_fnc_resourcesFIA;
 
 // Remove unit from server garrison data
 _troops deleteAt (_troops find _unitType);

--- a/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
@@ -211,7 +211,7 @@ if (_intelType == "Large") then
         {
             private _money = ((round (random 50)) + (10 * tierWar)) * 100;
             _text = format [localize "STR_A3A_fn_intel_select_mon_1", _money];
-            [0, _money] remoteExec ["A3A_fnc_resourcesFIA",2];
+            [teamPlayer, 0, _money] remoteExec ["A3A_fnc_resourcesFIA",2];
         };
     };
 };

--- a/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
@@ -53,7 +53,7 @@ if (not alive _official) then
 	[_taskId, "AS", "SUCCEEDED"] call A3A_fnc_taskSetState;
 	if (_difficultX) then
 		{
-		[0,600] remoteExec ["A3A_fnc_resourcesFIA",2];
+                [teamPlayer, 0, 600] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[2400, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[20,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 		[20,theBoss] call A3A_fnc_playerScoreAdd;
@@ -61,7 +61,7 @@ if (not alive _official) then
 		}
 	else
 		{
-		[0,300] remoteExec ["A3A_fnc_resourcesFIA",2];
+                [teamPlayer, 0, 300] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[1800, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 		[10,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -163,7 +163,7 @@ if (!([_traitor] call A3A_fnc_canFight) || traitorIntel) then
 	if(_difficultX) then {_factor = 2;};
     Debug("aggroEvent | Rebels won a traitor mission");
 	[Occupants, 15 * _factor, 120] remoteExec ["A3A_fnc_addAggression",2];
-	[0,300 * _factor] remoteExec ["A3A_fnc_resourcesFIA",2];
+        [teamPlayer, 0, 300 * _factor] remoteExec ["A3A_fnc_resourcesFIA",2];
 	{
 		if (!isPlayer _x) then
 		{
@@ -184,9 +184,10 @@ else
 	if (_difficultX) then {[-10,theBoss] call A3A_fnc_playerScoreAdd} else {[-10,theBoss] call A3A_fnc_playerScoreAdd};
 	if (dateToNumber date > _dateLimitNum) then
 	{
-		_hrT = server getVariable "hr";
-		_resourcesFIAT = server getVariable "resourcesFIA";
-		[-1*(round(_hrT/3)),-1*(round(_resourcesFIAT/3))] remoteExec ["A3A_fnc_resourcesFIA",2];
+                private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+                _hrT = _economy getOrDefault ["hr", 0];
+                _resourcesFIAT = _economy getOrDefault ["resources", 0];
+                [teamPlayer, -1*(round(_hrT/3)), -1*(round(_resourcesFIAT/3))] remoteExec ["A3A_fnc_resourcesFIA",2];
 	}
 	else
 	{

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -36,7 +36,7 @@ else
 {
 	private _bonus = [1, 1.5] select _difficultX;
 	[_taskId, "AS", "SUCCEEDED"] call A3A_fnc_taskSetState;
-	[0,200*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+     [teamPlayer, 0, 200*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
 	[800*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 	{if (isPlayer _x) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 	[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
@@ -65,14 +65,14 @@ else
 	[_taskId, "CON", "SUCCEEDED"] call A3A_fnc_taskSetState;
 	if (_difficultX) then
 		{
-		[0,400] remoteExec ["A3A_fnc_resourcesFIA",2];
+             [teamPlayer, 0, 400] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[800, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[20,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 		[20,theBoss] call A3A_fnc_playerScoreAdd;
 		}
 	else
 		{
-		[0,200] remoteExec ["A3A_fnc_resourcesFIA",2];
+             [teamPlayer, 0, 200] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[400, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 		[10,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Missions/fn_CON_PoliceStation.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_PoliceStation.sqf
@@ -34,7 +34,7 @@ else
 {
 	sleep 5;            // don't block the destruction message?
 	[_taskId, "SUPP", "SUCCEEDED"] call A3A_fnc_taskSetState;
-    [0,200] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, 0, 200] remoteExec ["A3A_fnc_resourcesFIA",2];
     [20, _marker, false] remoteExecCall ["A3A_fnc_citySupportChange", 2];           // no scaling? hmm
     {if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([300,0,_taskPos,teamPlayer] call A3A_fnc_distanceUnits);
     [10,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -388,7 +388,7 @@ if ((not alive _heli) || (_heli distance (getMarkerPos respawnTeamPlayer) < 100)
         Debug_1("%1 was captured", _heli);
     };
     [_taskId, "DES", "SUCCEEDED"] call A3A_fnc_taskSetState;
-    [0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, 0, 300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
     [600*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
     {if (_x distance _heli < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
     [10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
@@ -76,7 +76,7 @@ if (spawner getVariable _markerX == 0) then
 			{
 			["TaskFailed", ["", format ["AA Stolen in %1",_nameDest]]] remoteExec ["BIS_fnc_showNotification",_sideX]; //stringtable? this might be obsolete
 			};
-		[0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+             [teamPlayer, 0, 300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
         [_sideX, 5, 60] remoteExec ["A3A_fnc_addAggression", 2];
 		[400*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		{if (_x distance _veh < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));

--- a/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
@@ -105,7 +105,7 @@ if ((spawner getVariable _markerX != 2) and !(sidesX getVariable [_markerX,sideU
 		{
 
 			[_taskId, "LOG", "SUCCEEDED"] call A3A_fnc_taskSetState;
-			[0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+                    [teamPlayer, 0, 300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
 			[400*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 			{if (_x distance _truckX < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
 			[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -128,7 +128,7 @@ waitUntil {sleep 1; (dateToNumber date > _dateLimitNum) or (!alive _truckX) or (
 if ((_truckX distance _posbase < 50) and (dateToNumber date < _dateLimitNum)) then
 	{
 	[_taskId, "LOG", "SUCCEEDED"] call A3A_fnc_taskSetState;
-	[0,5000*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+        [teamPlayer, 0, 5000*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
     Debug("aggroEvent | Rebels won a bank mission");
 	[Occupants, 10, 120] remoteExec ["A3A_fnc_addAggression",2];
 	[400*_bonus, Occupants] remoteExec ["A3A_fnc_timingCA",2];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
@@ -128,7 +128,7 @@ if (_timeout && alive _box) then {
 	deleteVehicle _box;
 } else {
 	[_taskId, "LOG", "SUCCEEDED"] call A3A_fnc_taskSetState;
-	[0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, 0, 300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
 	{if (_x distance _box < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
 	[5*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
     Info("Mission Succeeded");

--- a/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
@@ -130,7 +130,7 @@ else
 	_countX = {(alive _x) and (_x distance getMarkerPos respawnTeamPlayer < 150)} count _POWs;
 	_hr = 2 * (_countX);
 	_resourcesFIA = 100 * _countX*_bonus;
-	[_hr,_resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, _hr, _resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];
 	[_hr*_bonus, _positionX] remoteExecCall ["A3A_fnc_citySupportChange", 2];
 	[Occupants, -(_countX * 1.5), 90] remoteExec ["A3A_fnc_addAggression",2];
 	{if (_x distance getMarkerPos respawnTeamPlayer < 500) then {[_countX,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));

--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -154,7 +154,7 @@ if (_sideX == Occupants) then
 		_countX = {(alive _x) and (_x distance getMarkerPos respawnTeamPlayer < 150)} count _POWs;
 		_hr = _countX;
 		_resourcesFIA = 100 * _countX;
-		[_hr,_resourcesFIA*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+            [teamPlayer, _hr, _resourcesFIA*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[Occupants, -10, 60] remoteExec ["A3A_fnc_addAggression",2];
 		{if (_x distance getMarkerPos respawnTeamPlayer < 500) then {[_countX*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
 		[round (_countX*_bonus/2),theBoss] call A3A_fnc_playerScoreAdd;
@@ -180,7 +180,7 @@ else
 		_countX = {(alive _x) and (_x distance getMarkerPos respawnTeamPlayer < 150)} count _POWs;
 		_hr = _countX;
 		_resourcesFIA = 100 * _countX;
-		[_hr,_resourcesFIA*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+            [teamPlayer, _hr, _resourcesFIA*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
 		{if (_x distance getMarkerPos respawnTeamPlayer < 500) then {[_countX*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
 		[round (_countX*_bonus/2),theBoss] call A3A_fnc_playerScoreAdd;
 		{[_x] join _groupPOW; [_x] orderGetin false} forEach _POWs;

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -354,7 +354,7 @@ if (_convoyType == "Ammunition") then
     else
     {
         [true, false, 400*_bonus, 10*_bonus, 10, 120, "ammo"] call _fnc_applyResults;
-        [0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+        [teamPlayer, 0, 300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
     };
 };
 
@@ -393,7 +393,7 @@ if (_convoyType == "Prisoners") then
             _countX = {(alive _x) and (_x distance _posHQ < 150)} count _POWs;
             [true, false, 400*_bonus, _bonus*_countX/2, 10, 120, "prisoner"] call _fnc_applyResults;
 
-            [_countX,_countX*300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+            [teamPlayer, _countX, _countX*300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
         };
     };
 };
@@ -444,7 +444,7 @@ if (_convoyType == "Money") then
         if (_vehObj distance _posHQ < 50) then
         {
             [true, false, 400*_bonus, 10*_bonus, 10, 120, "money"] call _fnc_applyResults;
-            [0,5000*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
+            [teamPlayer, 0, 5000*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
         };
     };
 };

--- a/A3A/addons/core/functions/OrgPlayers/fn_donateMoney.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_donateMoney.sqf
@@ -27,7 +27,7 @@ if (_resourcesPlayer < 100) exitWith {[_title, format [localize "STR_A3A_fn_orgp
 
 if (count _this == 0) exitWith
 	{
-	[0,100] remoteExec ["A3A_fnc_resourcesFIA",2];
+     [teamPlayer, 0, 100] remoteExec ["A3A_fnc_resourcesFIA",2];
 	_pointsXJ = (player getVariable "score") + 1;
 	player setVariable ["score",_pointsXJ,true];
 	[-100] call A3A_fnc_resourcesPlayer;

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerScoreAdd.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerScoreAdd.sqf
@@ -33,5 +33,5 @@ if (isMultiplayer) exitWith
 
 if (_pointsX > 0) then
 	{
-	if (_pointsX != 1) then {[0,(_pointsX * 5)] remoteExec ["A3A_fnc_resourcesFIA",2]} else {[0,20-(tierWar * 2)] remoteExec ["A3A_fnc_resourcesFIA",2]};
+     if (_pointsX != 1) then {[teamPlayer, 0, (_pointsX * 5)] remoteExec ["A3A_fnc_resourcesFIA",2]} else {[teamPlayer, 0, 20-(tierWar * 2)] remoteExec ["A3A_fnc_resourcesFIA",2]};
 	};

--- a/A3A/addons/core/functions/OrgPlayers/fn_sendMoney.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_sendMoney.sqf
@@ -54,7 +54,7 @@ if (_donateTo isEqualType "") exitWith {
         case ("faction"): {
             if ([-_donateAmount, _donateFrom] call A3A_fnc_resourcesPlayer) exitWith {
                 Info_3("%1 [UID: %2] donated $%3 to faction",name _donateFrom, getPlayerUID _donateFrom, _donateAmount);
-                [0, _donateAmount] call A3A_fnc_resourcesFIA;
+                [teamPlayer, 0, _donateAmount] call A3A_fnc_resourcesFIA;
                 private _scoreReward = 1 * (_donateAmount / 100);
                 player setVariable ["score", (player getVariable ["score", 0]) + _scoreReward, true];  // Raise player score for donating.
                 [_title, format [localize "STR_A3A_fn_orgp_donMon_donated_faction", _donateAmount]] remoteExecCall ["A3A_fnc_customHint", _donateFrom];

--- a/A3A/addons/core/functions/OrgPlayers/fn_theBossSteal.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_theBossSteal.sqf
@@ -4,9 +4,10 @@ FIX_LINE_NUMBERS()
 params [["_money",100]];
 private _titleStr = localize "STR_A3A_fn_orgp_tBSteal_titel";
 
-_resourcesFIA = server getVariable "resourcesFIA";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+_resourcesFIA = _economy getOrDefault ["resources", 0];
 if (_resourcesFIA < _money) exitWith {[_titleStr, format [localize "STR_A3A_fn_orgp_tBSteal_grab_no",FactionGet(reb,"name")]] call A3A_fnc_customHint;};
-server setvariable ["resourcesFIA",_resourcesFIA - _money, true];
+[teamPlayer, -_money, 0, true] call A3A_fnc_updateEconomyForSide;
 [-money/50,theBoss] call A3A_fnc_playerScoreAdd;
 [_money] call A3A_fnc_resourcesPlayer;
 

--- a/A3A/addons/core/functions/REINF/fn_FIAskillAdd.sqf
+++ b/A3A/addons/core/functions/REINF/fn_FIAskillAdd.sqf
@@ -6,15 +6,15 @@ if (player != theBoss) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_FIASkAdd
 
 if (skillFIA >= 20) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_FIASkAdd_training_max"] call A3A_fnc_customHint;};
 if (skillFIA >= (tierWar*2)) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_FIASkAdd_no_wl"] call A3A_fnc_customHint;};
-_resourcesFIA = server getVariable "resourcesFIA";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+_resourcesFIA = _economy getOrDefault ["resources", 0];
 _costs = 1000 + (1.5*(skillFIA *750));
 if (_resourcesFIA < _costs) exitWith {[_titleStr, format [localize "STR_A3A_fn_reinf_FIASkAdd_no_money",_costs]] call A3A_fnc_customHint;};
 
-_resourcesFIA = _resourcesFIA - _costs;
+[teamPlayer, 0, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 skillFIA = skillFIA + 1;
 [_titleStr, format [localize "STR_A3A_fn_reinf_FIASkAdd_upgraded",skillFIA,FactionGet(reb,"name")]] call A3A_fnc_customHint;
 publicVariable "skillFIA";
-server setVariable ["resourcesFIA",_resourcesFIA,true];
 
 //update tooltip
 _display = findDisplay 100;

--- a/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
@@ -28,8 +28,9 @@ private _costHR = 0;
 private _formatX = [];
 private _format = "Squd-";
 
-private _hr = server getVariable "hr";
-private _resourcesFIA = server getVariable "resourcesFIA";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _hr = _economy getOrDefault ["hr", 0];
+private _resourcesFIA = _economy getOrDefault ["resources", 0];
 
 if (_typeGroup isEqualType []) then {
     _formatX = _typeGroup;
@@ -109,7 +110,7 @@ private _vehiclePlacementMethod = if (getMarkerPos respawnTeamPlayer distance pl
 if (!_isInfantry) exitWith { [_vehType, _fnc_placed, _fnc_placeCheck, [_formatX, _idFormat, _special], _mounts] call _vehiclePlacementMethod };
 
 private _vehCost = [_vehType] call A3A_fnc_vehiclePrice;
-if (_isInfantry and (_costs + _vehCost) > server getVariable "resourcesFIA") exitWith {
+if (_isInfantry and (_costs + _vehCost) > _resourcesFIA) exitWith {
     [_titleStr, format [localize "STR_A3A_fn_reinf_addSqdHC_no_money2",_vehCost]] call A3A_fnc_customHint;
     [_formatX, _idFormat, _special, objNull] spawn A3A_fnc_spawnHCGroup;
 };

--- a/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
@@ -12,18 +12,8 @@ if (_typeVehX == "") exitWith {[_titleStr, localize "STR_A3A_fn_reinf_addFIAVeh_
 
 private _cost = [_typeVehX] call A3A_fnc_vehiclePrice;
 
-private _resourcesFIA = 0;
-if (!isMultiPlayer) then {_resourcesFIA = server getVariable "resourcesFIA"} else
-	{
-	if (player != theBoss) then
-		{
-		_resourcesFIA = player getVariable "moneyX";
-		}
-	else
-		{
-		_resourcesFIA = server getVariable "resourcesFIA";
-		};
-	};
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _resourcesFIA = _economy getOrDefault ["resources", 0];
 
 if (_resourcesFIA < _cost) exitWith {[_titleStr, format [localize "STR_A3A_fn_reinf_addFIAVeh_no_money",_cost]] call A3A_fnc_customHint;};
 private _nearestMarker = [markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer},player] call BIS_fnc_nearestPosition;
@@ -34,12 +24,10 @@ private _extraMessage =	format ["Buying vehicle for $%1.", _cost];
 private _fnc_placed = {
 	params ["_vehicle", "_cost"];
 	if (isNull _vehicle) exitWith {};
-	if (player == theBoss) then {
-		[0,(-1 * _cost)] remoteExec ["A3A_fnc_resourcesFIA",2];
-	} else {
-		[-1 * _cost] call A3A_fnc_resourcesPlayer;
-		_vehicle setVariable ["ownerX",getPlayerUID player,true];
-	};
+        [teamPlayer, 0, -_cost] remoteExec ["A3A_fnc_resourcesFIA",2];
+        if (player != theBoss) then {
+                _vehicle setVariable ["ownerX",getPlayerUID player,true];
+        };
 	_vehicle setFuel random [0.10, 0.175, 0.25];
 	[_vehicle, teamPlayer] call A3A_fnc_AIVehInit;
 	["", _vehicle] remoteExecCall ["A3A_fnc_garrisonServer_addVehicle", 2];

--- a/A3A/addons/core/functions/REINF/fn_addToGarrisonServer.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addToGarrisonServer.sqf
@@ -28,7 +28,7 @@ if (_limit != -1 and _newGarrisonCount >= _limit) then {
         deleteVehicle _x;
     } forEach _unitsToRefund;
 
-    [count _unitsToRefund,_refundMoney] remoteExec ["A3A_fnc_resourcesFIA",2];
+    [teamPlayer, count _unitsToRefund, _refundMoney] remoteExec ["A3A_fnc_resourcesFIA",2];
     [_titleStr, localize "STR_A3A_garrison_exceed_limit"] remoteExecCall ["A3A_fnc_customHint", _player];
 };
 

--- a/A3A/addons/core/functions/REINF/fn_build.sqf
+++ b/A3A/addons/core/functions/REINF/fn_build.sqf
@@ -116,7 +116,8 @@ private _textX = "";
 if ((build_type == "SB") or (build_type == "CB")) then
 	{
 	if (build_type == "SB") then {_playerDir = _playerDir + 180};
-	_resourcesFIA = if (!isMultiPlayer) then {server getVariable "resourcesFIA"} else {player getVariable "moneyX"};
+        private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+        _resourcesFIA = _economy getOrDefault ["resources", 0];
 	if (build_cost > _resourcesFIA) then
 		{
 		_leave = true;

--- a/A3A/addons/core/functions/REINF/fn_buildCreateVehicleCallback.sqf
+++ b/A3A/addons/core/functions/REINF/fn_buildCreateVehicleCallback.sqf
@@ -41,16 +41,9 @@ build_targetLocation = nil;
 
 
 if (build_cost > 0) then
-	{
-	if (!isMultiPlayer) then
-		{
-		_nul = [0, - build_cost] remoteExec ["A3A_fnc_resourcesFIA",2];
-		}
-	else
-		{
-		[-build_cost] call A3A_fnc_resourcesPlayer;
-		};
-	};
+        {
+        [teamPlayer, 0, - build_cost] remoteExec ["A3A_fnc_resourcesFIA",2];
+        };
 
 build_engineerSelected setVariable ["constructing",true];
 

--- a/A3A/addons/core/functions/REINF/fn_buildMinefield.sqf
+++ b/A3A/addons/core/functions/REINF/fn_buildMinefield.sqf
@@ -9,7 +9,7 @@ _positionTel = _this select 1;
 _quantity = _this select 2;
 private _typeExp = FactionGet(reb,"unitExp");
 _costs = 2*(server getVariable _typeExp) + ([(FactionGet(reb,"vehiclesTruck")) # 0] call A3A_fnc_vehiclePrice);
-[-2,(-1*_costs)] remoteExec ["A3A_fnc_resourcesFIA",2];
+[teamPlayer, -2, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 
 if (_typeX == "ATMine") then
 	{
@@ -124,7 +124,7 @@ if ((_truckX distance _positionTel < 50) and ({alive _x} count units _groupX > 0
 		[_taskId, "Mines", "SUCCEEDED"] call A3A_fnc_taskSetState;
 		sleep 15;
 		[_taskId, "Mines", 0] spawn A3A_fnc_taskDelete;
-		[2,_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+                [teamPlayer, 2, _costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 		}
 	else
 		{

--- a/A3A/addons/core/functions/REINF/fn_canReinfPlayer.sqf
+++ b/A3A/addons/core/functions/REINF/fn_canReinfPlayer.sqf
@@ -15,11 +15,12 @@ if ((count units group player) + (count units stragglers) > 9) exitWith {localiz
 private _hasWeapons = [_typeUnit] call A3A_fnc_hasWeapons;
 if !(_hasWeapons) exitWith {localize "STR_A3A_fn_reinf_reinfPlayer_no_weapons"};
 
-private _hr = server getVariable "hr";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+private _hr = _economy getOrDefault ["hr", 0];
 if (_hr < 1) exitWith {localize "STR_A3A_fn_reinf_reinfPlayer_no_hr"};
 
 private _costs = server getVariable _typeUnit;
-private _resources = if (player == theBoss) then { server getVariable "resourcesFIA" } else { player getVariable "moneyX" };
+private _resources = _economy getOrDefault ["resources", 0];
 if (_costs > _resources) exitWith {format [localize "STR_A3A_fn_reinf_reinfPlayer_no_money",_costs]};
 
 "";

--- a/A3A/addons/core/functions/REINF/fn_dismissPlayerGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_dismissPlayerGroup.sqf
@@ -54,7 +54,7 @@ if ([_unit] call A3A_fnc_canFight) then
 	};
 deleteVehicle _x;
 } forEach units _newGroup;
-if (!isMultiplayer) then {_nul = [_hr,_resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];} else {_nul = [_hr,0] remoteExec ["A3A_fnc_resourcesFIA",2]; [_resourcesFIA] call A3A_fnc_resourcesPlayer};
+[teamPlayer, _hr, _resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];
 {boxX addWeaponCargoGlobal [_x,1]} forEach _weaponsX;
 {boxX addMagazineCargoGlobal [_x,1]} forEach _ammunition;
 {boxX addItemCargoGlobal [_x,1]} forEach _items;

--- a/A3A/addons/core/functions/REINF/fn_dismissSquad.sqf
+++ b/A3A/addons/core/functions/REINF/fn_dismissSquad.sqf
@@ -79,4 +79,4 @@ private _assignedVehicles =	[];
 	deleteVehicle _veh;
 } forEach _assignedVehicles;
 
-_nul = [_hr,_resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];
+[teamPlayer, _hr, _resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];

--- a/A3A/addons/core/functions/REINF/fn_reinfPlayer.sqf
+++ b/A3A/addons/core/functions/REINF/fn_reinfPlayer.sqf
@@ -10,12 +10,7 @@ private _unit = [group player, _typeUnit, position player, [], 0, "NONE"] call A
 
 private _costs = server getVariable _typeUnit;
 
-if (player == theBoss) then {
-	[-1, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
-} else {
-	[-1, 0] remoteExec ["A3A_fnc_resourcesFIA",2];
-	[- _costs] call A3A_fnc_resourcesPlayer;
-};
+[teamPlayer, -1, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 [_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_recruited"] call A3A_fnc_customHint;
 
 [_unit] spawn A3A_fnc_FIAinit;

--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -122,7 +122,7 @@ switch _special do {
     };
 };
 
-[- _costHR, - _cost] remoteExec ["A3A_fnc_resourcesFIA", 2];
+[teamPlayer, - _costHR, - _cost] remoteExec ["A3A_fnc_resourcesFIA", 2];
 
 if !(_bypassAI) then {_group spawn A3A_fnc_attackDrillAI};
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -71,8 +71,9 @@ private _sideToStr = createHashMapFromArray [[teamPlayer,0], [Occupants,1],	[Inv
 
 private ["_hrBackground","_resourcesBackground","_veh","_typeVehX","_weaponsX","_ammunition","_items","_backpcks","_containers","_arrayEst","_posVeh","_dierVeh","_prestigeOPFOR","_prestigeBLUFOR","_city","_dataX","_markersX","_garrison","_arrayMrkMF","_arrayOutpostsFIA","_positionOutpost","_typeMine","_posMine","_detected","_typesX","_exists","_friendX"];
 
-_hrBackground = (server getVariable "hr") + ({(alive _x) and (not isPlayer _x) and (_x getVariable ["spawner",false]) and ((group _x in (hcAllGroups theBoss) or (isPlayer (leader _x))) and (side group _x == teamPlayer))} count allUnits);
-_resourcesBackground = server getVariable "resourcesFIA";
+private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+_hrBackground = (_economy getOrDefault ["hr", 0]) + ({(alive _x) and (not isPlayer _x) and (_x getVariable ["spawner",false]) and ((group _x in (hcAllGroups theBoss) or (isPlayer (leader _x))) and (side group _x == teamPlayer))} count allUnits);
+_resourcesBackground = _economy getOrDefault ["resources", 0];
 
 // TODO: Sort this garbage out
 {

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -33,7 +33,7 @@ private _fnc_placed = {
     };
 
     if (_price > 0) then {
-        if (_unit == theBoss) exitWith { [0, -_price] remoteExec ["A3A_fnc_resourcesFIA", 2] };
+        if (_unit == theBoss) exitWith { [teamPlayer, 0, -_price] remoteExec ["A3A_fnc_resourcesFIA", 2] };
         [-_price] call A3A_fnc_resourcesPlayer;     // uh, we're just assuming _unit == player here
     };
 

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -197,7 +197,7 @@ player addEventHandler ["GetOutMan", {
 }];
 
 player addEventHandler ["Killed", {
-    [-1, 0] remoteExecCall ["A3A_fnc_resourcesFIA", 2];
+    [teamPlayer, -1, 0] remoteExecCall ["A3A_fnc_resourcesFIA", 2];
 }];
 
 // Prevent players getting shot by their own AIs. EH is respawn-persistent

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -46,8 +46,7 @@ while {true} do
 
 	Debug_2("Occupant radio keys: %1 - Invader radio keys: %2", occRadioKeys, invRadioKeys);
 
-	server setVariable ["hr", _hrAdd + (server getVariable "hr"), true];
-	server setVariable ["resourcesFIA", ceil _resAdd + (server getVariable "resourcesFIA"), true];
+        [teamPlayer, ceil _resAdd, _hrAdd] call A3A_fnc_updateEconomyForSide;
 
 	private _newBombRuns = bombRuns + 0.25 * ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX);
 	bombRuns = _newBombRuns min (4 + tierWar*2);

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -149,7 +149,7 @@ HR_GRG_disableSellButton = false;
 
 HR_GRG_addResources = {
     params ["_money"];
-    [0,_money] call A3A_fnc_resourcesFIA;
+    [teamPlayer, 0, _money] call A3A_fnc_resourcesFIA;
 };
 
 HR_GRG_canSell = {_this isEqualTo theBoss};

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -86,7 +86,7 @@ private _utilityRefund = {
     deleteVehicle _object;
     if (_instantRefund) exitWith {
         if (_toRefund > 0) then {
-            [0,_toRefund] spawn A3A_fnc_resourcesFIA;
+            [teamPlayer, 0, _toRefund] spawn A3A_fnc_resourcesFIA;
         };
         [_feedBack] remoteExec ["HR_GRG_fnc_Hint", _client];
         true;

--- a/A3A/addons/gui/functions/GUI/fn_recruitDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_recruitDialog.sqf
@@ -95,8 +95,9 @@ switch (_mode) do
         _aaMissilePriceText ctrlSetText ((str _aaMissilePrice) + "€");
 
         // Disable buttons and darken icon if not enough money or HR for the unit
-        private _money = if (player == theBoss) then { server getVariable "resourcesFIA" } else { player getVariable "moneyX" };
-        private _hr = server getVariable "hr";
+        private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+        private _money = _economy getOrDefault ["resources", 0];
+        private _hr = _economy getOrDefault ["hr", 0];
         if (_money < _militiamanPrice || _hr < 1) then {
             _militiamanButton ctrlEnable false;
             _militiamanButton ctrlSetTooltip localize "STR_antistasi_dialogs_recruit_units_error";

--- a/A3A/addons/gui/functions/GUI/fn_recruitSquadDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_recruitSquadDialog.sqf
@@ -178,8 +178,9 @@ switch (_mode) do
         _aaTruckPriceText ctrlSetText (format ["%1 € %2 HR", _aaTruckMoney, _aaTruckHr]);
 
         // Disable buttons and darken icon if not enough money or HR for the squad
-        private _money = server getVariable "resourcesFIA";
-        private _hr = server getVariable "hr";
+        private _economy = [teamPlayer, true] call A3A_fnc_getEconomyForSide;
+        private _money = _economy getOrDefault ["resources", 0];
+        private _hr = _economy getOrDefault ["hr", 0];
         if (_money < _infSquadMoney || _hr < _infSquadHr) then {
             _infSquadButton ctrlEnable false;
             _infSquadButton ctrlSetTooltip localize "STR_antistasi_recruit_squad_error";

--- a/A3A/addons/gui/functions/gunShop/fn_checkOut.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_checkOut.sqf
@@ -28,7 +28,7 @@ if((player == theBoss && server getVariable ["resourcesFIA", 0] < _totalCost)) e
     [localize "STR_A3A_Utility_Items_Purchase_Title", localize "STR_A3A_Utility_Items_Insufficient_Funds"] call A3A_fnc_customHint;
 };
 
-if (player == theBoss) then { [0, -_totalCost] remoteExec ["A3A_fnc_resourcesFIA", 2] };
+if (player == theBoss) then { [teamPlayer, 0, -_totalCost] remoteExec ["A3A_fnc_resourcesFIA", 2] };
 private _shoppingCartList = [];
 {
 	private _key = _x;

--- a/A3A/addons/tasks/Tasks/fn_LOG_Supplies.sqf
+++ b/A3A/addons/tasks/Tasks/fn_LOG_Supplies.sqf
@@ -184,7 +184,7 @@ _task set ["s_succeeded", {
 	[5*_bonus, theBoss] call A3A_fnc_playerScoreAdd;
 
 	[15 * _bonus, _marker] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	[0, 200 * _bonus] remoteExec ["A3A_fnc_resourcesFIA", 2];
+    [teamPlayer, 0, 200 * _bonus] remoteExec ["A3A_fnc_resourcesFIA", 2];
 
 	[_this get "_taskId", "SUCCEEDED"] call BIS_fnc_taskSetState;
 	_this set ["state", "s_cleanup"]; false;

--- a/A3A/addons/tasks/Tasks/fn_city_repair.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_repair.sqf
@@ -165,7 +165,7 @@ _task set ["s_success", {
 	[5, theBoss] call A3A_fnc_playerScoreAdd;
 
 	[8, _this get "_marker"] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	[0, 100] spawn A3A_fnc_resourcesFIA;
+    [teamPlayer, 0, 100] spawn A3A_fnc_resourcesFIA;
 
 	[_this get "_taskId", "SUCCEEDED"] call BIS_fnc_taskSetState;
 	_this set ["state", "s_cleanup"]; false;

--- a/A3A/addons/tasks/Tasks/fn_city_taxi.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_taxi.sqf
@@ -137,7 +137,7 @@ _task set ["s_success", {
     // TODO: Maybe both ends?
     private _distance = markerPos (_this get "_marker") distance2d (_this get "_destPos");
 	[5 + _distance/400, _this get "_marker"] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	[0, 200] remoteExec ["A3A_fnc_resourcesFIA", 2];
+    [teamPlayer, 0, 200] remoteExec ["A3A_fnc_resourcesFIA", 2];
 
 	[_this get "_taskId", "SUCCEEDED"] call BIS_fnc_taskSetState;
 	_this set ["state", "s_cleanup"]; false;


### PR DESCRIPTION
## Summary
- update A3A_fnc_resourcesFIA to accept a faction side, use the shared economy helpers and commander-aware notifications
- migrate base, reinforcement, AI and mission reward scripts to use side-scoped economy accessors instead of server variables or player wallets
- adjust UI, garrison and utility flows to supply the side with every resourcesFIA call and rely on the commander economy entry for balance checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e326dac980832f904ee0c87b5d01d9