### PR TITLE
Add side-aware HQ management for Civil War command structures

### DIFF
--- a/A3A/addons/core/functions/Base/fn_buildHQ.sqf
+++ b/A3A/addons/core/functions/Base/fn_buildHQ.sqf
@@ -13,62 +13,99 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-if (A3A_petrosMoving) then {
-	A3A_petrosMoving = false; publicVariable "A3A_petrosMoving";
+params [["_sideInput", teamPlayer]];
 
-	private _groupPetros = createGroup teamPlayer;
-	[petros] join _groupPetros;
-	_groupPetros selectLeader petros;
+private _structure = [_sideInput, true] call A3A_fnc_getCommandStructureForSide;
+if !(typeName _structure isEqualTo "HASHMAP") exitWith {
+    Error("buildHQ called without a valid command structure context");
+};
 
-	group petros setGroupOwner 2;
-	[] spawn {
-		waitUntil {sleep 0.01; local petros};
-		petros switchAction "PlayerStand";
-		petros disableAI "MOVE";
-		petros disableAI "AUTOTARGET";
-		petros setBehaviour "SAFE";
-	};
+private _side = _structure getOrDefault ["side", _sideInput];
+if !(typeName _side isEqualTo "SIDE") then { _side = _sideInput; };
+private _sideKey = _structure getOrDefault ["sideKey", [_sideInput] call A3A_fnc_sideToKey];
+private _isRebelSide = _sideKey isEqualTo ([teamPlayer] call A3A_fnc_sideToKey);
 
-	[respawnTeamPlayer, 1, teamPlayer] call A3A_fnc_setMarkerAlphaForSide;
-	[respawnTeamPlayer, 1, civilian] call A3A_fnc_setMarkerAlphaForSide;
+private _hqObjects = _structure getOrDefault ["hqObjects", createHashMap];
+private _advisor = _hqObjects getOrDefault ["advisor", petros];
+private _respawnMarker = _structure getOrDefault ["respawnMarker", "respawnTeamPlayer"];
+private _hqMarker = _structure getOrDefault ["hqMarker", "Synd_HQ"];
+private _hqGarrison = _structure getOrDefault ["hqGarrison", _hqMarker];
+
+if (_structure getOrDefault ["hqMoving", false]) then {
+        _structure set ["hqMoving", false];
+        if (_isRebelSide) then {
+                A3A_petrosMoving = false; publicVariable "A3A_petrosMoving";
+        };
+
+        if !(isNull _advisor) then {
+                private _groupAdvisor = createGroup _side;
+                [_advisor] join _groupAdvisor;
+                _groupAdvisor selectLeader _advisor;
+
+                group _advisor setGroupOwner 2;
+                private _advisorRef = _advisor;
+                [_advisorRef] spawn {
+                        params ["_unit"];
+                        waitUntil {sleep 0.01; local _unit};
+                        _unit switchAction "PlayerStand";
+                        _unit disableAI "MOVE";
+                        _unit disableAI "AUTOTARGET";
+                        _unit setBehaviour "SAFE";
+                };
+        };
+
+        if !(_respawnMarker isEqualTo "") then {
+                [_respawnMarker, 1, _side] call A3A_fnc_setMarkerAlphaForSide;
+                [_respawnMarker, 1, civilian] call A3A_fnc_setMarkerAlphaForSide;
+        };
 };
 
 
 // Update cur/old HQ knowledge
-private _oldPos = markerPos "Synd_HQ";
-private _newPos = getPosATL petros;
+private _oldPos = if (_hqMarker isEqualTo "") then {[0,0,0]} else {markerPos _hqMarker};
+private _newPos = if (isNull _advisor) then {_oldPos} else {getPosATL _advisor};
 
-_oldPos set [2, A3A_curHQInfoOcc];
-A3A_oldHQInfoOcc pushBack +_oldPos;
-A3A_curHQInfoOcc = 0;
-{
-	private _dist = _x distance2d _newPos;
-	A3A_curHQInfoOcc = A3A_curHQInfoOcc max linearConversion [0, 1000, _dist, _x#2, 0, true];
-} forEach A3A_oldHQInfoOcc;
+if (_isRebelSide) then {
+        _oldPos set [2, A3A_curHQInfoOcc];
+        A3A_oldHQInfoOcc pushBack +_oldPos;
+        A3A_curHQInfoOcc = 0;
+        {
+                private _dist = _x distance2d _newPos;
+                A3A_curHQInfoOcc = A3A_curHQInfoOcc max linearConversion [0, 1000, _dist, _x#2, 0, true];
+        } forEach A3A_oldHQInfoOcc;
 
-_oldPos set [2, A3A_curHQInfoInv];
-A3A_oldHQInfoInv pushBack +_oldPos;
-A3A_curHQInfoInv = 0;
-{
-	private _dist = _x distance2d _newPos;
-	A3A_curHQInfoInv = A3A_curHQInfoInv max linearConversion [0, 1000, _dist, _x#2, 0, true];
-} forEach A3A_oldHQInfoInv;
+        _oldPos set [2, A3A_curHQInfoInv];
+        A3A_oldHQInfoInv pushBack +_oldPos;
+        A3A_curHQInfoInv = 0;
+        {
+                private _dist = _x distance2d _newPos;
+                A3A_curHQInfoInv = A3A_curHQInfoInv max linearConversion [0, 1000, _dist, _x#2, 0, true];
+        } forEach A3A_oldHQInfoInv;
+};
 
 
 // Do the actual HQ position set
-respawnTeamPlayer setMarkerPos _newPos;
-posHQ = _newPos; publicVariable "posHQ";
-"Synd_HQ" setMarkerPos _newPos;
+if !(_respawnMarker isEqualTo "") then { _respawnMarker setMarkerPos _newPos; };
+if (_isRebelSide) then {
+        posHQ = _newPos; publicVariable "posHQ";
+};
+if !(_hqMarker isEqualTo "") then { _hqMarker setMarkerPos _newPos; };
 
-chopForest = false; publicVariable "chopForest";
+_structure set ["hqPosition", _newPos];
 
-[_newPos] call A3A_fnc_relocateHQObjects;
+if (_isRebelSide) then {
+        chopForest = false; publicVariable "chopForest";
+};
+
+[_newPos, _sideInput] call A3A_fnc_relocateHQObjects;
 
 
 // Move nearby buildings, statics & vehicles into HQ garrison
-private _buildingsInArea = A3A_buildingsToSave inAreaArray "Synd_HQ";
+private _buildingsInArea = if (_hqMarker isEqualTo "") then {[]} else {A3A_buildingsToSave inAreaArray _hqMarker};
 {
-	["Synd_HQ", _x] call A3A_fnc_garrisonServer_addVehicle;
+        if !(_hqGarrison isEqualTo "") then {
+                [_hqGarrison, _x] call A3A_fnc_garrisonServer_addVehicle;
+        };
 } forEach _buildingsInArea;
 A3A_buildingsToSave = A3A_buildingsToSave - _buildingsInArea;
 
@@ -81,12 +118,16 @@ A3A_buildingsToSave = A3A_buildingsToSave - _buildingsInArea;
 
 	if (_x isKindOf "staticWeapon") then {
 		if (!isNull attachedTo _x) then { continue };
-	} else {
-		if (count crew _x != 0) then { continue };
-	};
+        } else {
+                if (count crew _x != 0) then { continue };
+        };
 
-	["Synd_HQ", _x] call A3A_fnc_garrisonServer_addVehicle;
+        if !(_hqGarrison isEqualTo "") then {
+                [_hqGarrison, _x] call A3A_fnc_garrisonServer_addVehicle;
+        };
 
-} forEach (vehicles inAreaArray "Synd_HQ");
+} forEach (if (_hqMarker isEqualTo "") then {[]} else {vehicles inAreaArray _hqMarker});
+
+[_sideInput, _structure] call A3A_fnc_setCommandStructureForSide;
 
 ["HQPlaced", [_newPos]] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Base/fn_canMoveHQ.sqf
+++ b/A3A/addons/core/functions/Base/fn_canMoveHQ.sqf
@@ -20,24 +20,35 @@ Example:
 [player] call A3A_fnc_canMoveHQ;
 */
 
-params ["_player"];
+params [
+    ["_player", objNull, [objNull]],
+    ["_sideInput", teamPlayer]
+];
+
+private _structure = [_sideInput, true] call A3A_fnc_getCommandStructureForSide;
+private _commander = _structure getOrDefault ["commander", objNull];
+if (isNull _commander) then { _commander = theBoss; };
 
 private _result = [false];
 private _titleStr = localize "STR_A3A_fn_base_canmovehq_title";
 
-if (_player != theBoss) then
+if (!isNull _player && {!isNull _commander} && {_player != _commander}) then
 {
     [_titleStr, localize "STR_A3A_fn_base_canmovehq_no_comm"] call A3A_fnc_customHint;
     _result pushBack localize "STR_A3A_fn_base_canmovehq_comm_only";
 };
 
-if !(isNull attachedTo petros) then
+private _advisor = (_structure getOrDefault ["hqObjects", createHashMap]) getOrDefault ["advisor", petros];
+if !(isNull _advisor) then
 {
-    if(count _result == 1) then
+    if !(isNull attachedTo _advisor) then
     {
-        [_titleStr, localize "STR_A3A_fn_base_canmovehq_petros_down"] call A3A_fnc_customHint;
+        if(count _result == 1) then
+        {
+            [_titleStr, localize "STR_A3A_fn_base_canmovehq_petros_down"] call A3A_fnc_customHint;
+        };
+        _result pushBack localize "STR_A3A_fn_base_canmovehq_petros_pickedup";
     };
-    _result pushBack localize "STR_A3A_fn_base_canmovehq_petros_pickedup";
 };
 
 if(count _result != 1) exitWith

--- a/A3A/addons/core/functions/Base/fn_moveHQ.sqf
+++ b/A3A/addons/core/functions/Base/fn_moveHQ.sqf
@@ -12,33 +12,83 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_player"];
+params [
+    ["_player", objNull, [objNull]],
+    ["_sideInput", teamPlayer]
+];
 
-if (A3A_petrosMoving) exitWith {
-	Error("MoveHQ called when petros was moving");
+private _structure = [_sideInput, true] call A3A_fnc_getCommandStructureForSide;
+if !(typeName _structure isEqualTo "HASHMAP") exitWith {
+    Error("MoveHQ called without a command structure context");
 };
 
-private _possible = [_player] call A3A_fnc_canMoveHQ;
+private _side = _structure getOrDefault ["side", _sideInput];
+if !(typeName _side isEqualTo "SIDE") then { _side = _sideInput; };
+private _sideKey = _structure getOrDefault ["sideKey", [_sideInput] call A3A_fnc_sideToKey];
+private _isRebelSide = _sideKey isEqualTo ([teamPlayer] call A3A_fnc_sideToKey);
+
+private _moveInProgress = _structure getOrDefault ["hqMoving", false];
+if (_isRebelSide && {A3A_petrosMoving}) exitWith {
+    Error("MoveHQ called when petros was moving");
+};
+if (!_isRebelSide && {_moveInProgress}) exitWith {
+    Error_1("MoveHQ called while HQ move already active for %1", _sideKey);
+};
+
+private _possible = [_player, _sideInput] call A3A_fnc_canMoveHQ;
 private _titleStr = localize "STR_A3A_fn_base_movehq_garrison";
 
 if !(_possible#0) exitWith {
-    [_titleStr, _possible#1] remoteExecCall ["customHint", _client];
+    if (!isNull _player) then {
+        [_titleStr, _possible#1] remoteExecCall ["customHint", owner _player];
+    };
 };
 
-A3A_petrosMoving = true; publicVariable "A3A_petrosMoving";
+_structure set ["hqMoving", true];
+[_sideInput, _structure] call A3A_fnc_setCommandStructureForSide;
+
+if (_isRebelSide) then {
+    A3A_petrosMoving = true; publicVariable "A3A_petrosMoving";
+};
 
 // The enableAI commands will only affect localhost
-petros setBehaviour "AWARE";
-petros enableAI "MOVE";
-petros enableAI "AUTOTARGET";
+private _hqObjects = _structure getOrDefault ["hqObjects", createHashMap];
+private _advisor = _hqObjects getOrDefault ["advisor", petros];
+private _campObject = _hqObjects getOrDefault ["camp", fireX];
 
-private _groupPetros = group petros;
-[petros] join theBoss;
-deleteGroup _groupPetros;
+if !(isNull _advisor) then {
+    _advisor setBehaviour "AWARE";
+    _advisor enableAI "MOVE";
+    _advisor enableAI "AUTOTARGET";
 
-fireX inflame false;
+    private _groupAdvisor = group _advisor;
+    private _commander = [_sideInput] call A3A_fnc_getCommanderForSide;
+    if (isNull _commander) then { _commander = theBoss; };
 
-[respawnTeamPlayer, 0, teamPlayer] call A3A_fnc_setMarkerAlphaForSide;
-[respawnTeamPlayer, 0, civilian] call A3A_fnc_setMarkerAlphaForSide;
+    if (!isNull _commander) then {
+        [_advisor] join _commander;
+    };
 
-["Synd_HQ", false, true, true] call A3A_fnc_garrisonServer_clear;
+    if (!isNull _groupAdvisor && {_groupAdvisor != group _advisor}) then {
+        deleteGroup _groupAdvisor;
+    };
+};
+
+if !(isNull _campObject) then {
+    try {
+        _campObject inflame false;
+    } catch {
+        // Some HQ camp objects do not support inflame, ignore
+    };
+};
+
+private _respawnMarker = _structure getOrDefault ["respawnMarker", ""];
+if !(_respawnMarker isEqualTo "") then {
+    [_respawnMarker, 0, _side] call A3A_fnc_setMarkerAlphaForSide;
+    [_respawnMarker, 0, civilian] call A3A_fnc_setMarkerAlphaForSide;
+};
+
+private _hqGarrison = _structure getOrDefault ["hqGarrison", _structure getOrDefault ["hqMarker", ""]];
+if !(_hqGarrison isEqualTo "") then {
+    [_hqGarrison, false, true, true] call A3A_fnc_garrisonServer_clear;
+};

--- a/A3A/addons/core/functions/Base/fn_relocateHQObjects.sqf
+++ b/A3A/addons/core/functions/Base/fn_relocateHQObjects.sqf
@@ -1,7 +1,29 @@
 // Reset positions of all HQ objects except petros
 // Server, unscheduled
 
-params ["_newPos"];
+params [
+    ["_newPos", [0,0,0], [[]]],
+    ["_sideInput", teamPlayer]
+];
+
+private _structure = [_sideInput, true] call A3A_fnc_getCommandStructureForSide;
+if !(typeName _structure isEqualTo "HASHMAP") exitWith {
+        Error("relocateHQObjects called without a valid command structure context");
+};
+
+if (_newPos isEqualTo [0,0,0]) then {
+        _newPos = _structure getOrDefault ["hqPosition", _newPos];
+};
+
+private _hqObjects = _structure getOrDefault ["hqObjects", createHashMap];
+private _advisor = _hqObjects getOrDefault ["advisor", petros];
+private _campObject = _hqObjects getOrDefault ["camp", fireX];
+private _crateObject = _hqObjects getOrDefault ["crate", boxX];
+private _mapObject = _hqObjects getOrDefault ["map", mapX];
+private _vehicleObject = _hqObjects getOrDefault ["vehicleCrate", vehicleBox];
+private _flagObject = _hqObjects getOrDefault ["flag", flagX];
+
+private _advisorDir = if (isNull _advisor) then {0} else {getDir _advisor};
 
 // Move headless client logic objects near HQ so that firedNear EH etc. work more reliably
 private _hcpos = _newPos vectorAdd [-100, -100, 0];
@@ -12,30 +34,40 @@ private _alignNormals = {
 	_thing setVectorUp surfaceNormal getPos _thing;
 };
 
-private _firePos = [_newPos, 3, getDir petros] call BIS_Fnc_relPos;
+private _firePos = [_newPos, 3, _advisorDir] call BIS_fnc_relPos;
 //Extra height on the fire to avoid it clipping into the ground
-fireX setPos (_firePos vectorAdd [0,0,0.1]);
-_rnd = getdir petros;
-_pos = [_firePos, 3, _rnd] call BIS_Fnc_relPos;
-boxX setPos _pos;
-_rnd = _rnd + 45;
-_pos = [_firePos, 3, _rnd] call BIS_Fnc_relPos;
-mapX setDir ([_firePos, _pos] call BIS_fnc_dirTo);
-mapX setPos _pos;
-_rnd = _rnd + 45;
-_pos = [_firePos, 3, _rnd] call BIS_Fnc_relPos;
-_emptyPos = _pos findEmptyPosition [0,50,(typeOf flagX)];
-_pos = if (count _emptyPos > 0) then {_emptyPos} else {_pos};
-flagX setPos _pos;
-_rnd = _rnd + 45;
-_pos = [_firePos, 3, _rnd] call BIS_Fnc_relPos;
-vehicleBox setPos _pos;
+if !(isNull _campObject) then {
+        _campObject setPos (_firePos vectorAdd [0,0,0.1]);
+};
 
-//Align with ground. Deliberately ignoring flagX, because a flag pole at 45 degrees looks /weird/
-{_x call _alignNormals} forEach [fireX, boxX, mapX, vehicleBox];
+private _rnd = _advisorDir;
+private _pos = [_firePos, 3, _rnd] call BIS_fnc_relPos;
+if !(isNull _crateObject) then { _crateObject setPos _pos; };
 
-boxX hideObjectGlobal false;
-vehicleBox hideObjectGlobal false;
-mapX hideObjectGlobal false;
-fireX hideObjectGlobal false;
-flagX hideObjectGlobal false;
+_rnd = _rnd + 45;
+_pos = [_firePos, 3, _rnd] call BIS_fnc_relPos;
+if !(isNull _mapObject) then {
+        _mapObject setDir ([_firePos, _pos] call BIS_fnc_dirTo);
+        _mapObject setPos _pos;
+};
+
+_rnd = _rnd + 45;
+_pos = [_firePos, 3, _rnd] call BIS_fnc_relPos;
+if !(isNull _flagObject) then {
+        private _emptyPos = _pos findEmptyPosition [0,50,(typeOf _flagObject)];
+        _pos = if (count _emptyPos > 0) then {_emptyPos} else {_pos};
+        _flagObject setPos _pos;
+};
+
+_rnd = _rnd + 45;
+_pos = [_firePos, 3, _rnd] call BIS_fnc_relPos;
+if !(isNull _vehicleObject) then { _vehicleObject setPos _pos; };
+
+//Align with ground. Deliberately ignoring flag, because a flag pole at 45 degrees looks weird
+{
+        if !(isNull _x) then { _x call _alignNormals; };
+} forEach [_campObject, _crateObject, _mapObject, _vehicleObject];
+
+{
+        if !(isNull _x) then { _x hideObjectGlobal false; };
+} forEach [_crateObject, _vehicleObject, _mapObject, _campObject, _flagObject];

--- a/A3A/addons/core/functions/Command/fn_defaultCommandStructure.sqf
+++ b/A3A/addons/core/functions/Command/fn_defaultCommandStructure.sqf
@@ -22,9 +22,12 @@ private _structure = createHashMap;
 _structure set ["sideKey", _sideKey];
 _structure set ["side", _sideInput];
 _structure set ["commander", objNull];
-_structure set ["hqObjects", []];
+_structure set ["hqObjects", createHashMap];
 _structure set ["hqPosition", [0,0,0]];
 _structure set ["hqMarker", ""];
+_structure set ["respawnMarker", ""];
+_structure set ["hqGarrison", ""];
+_structure set ["hqMoving", false];
 _structure set ["economy", createHashMapFromArray [
     ["resources", 0],
     ["hr", 0],

--- a/A3A/addons/core/functions/init/fn_initCivilWarMode.sqf
+++ b/A3A/addons/core/functions/init/fn_initCivilWarMode.sqf
@@ -36,6 +36,111 @@ private _applyBaseline = toLower _startType == "new";
     [Invaders, "CSAT"]
 ];
 
+private _hqDefinitions = [
+    [Occupants, "NATO", "NATO_carrier", "Flag_NATO_F", "B_officer_F"],
+    [Invaders, "CSAT", "CSAT_carrier", "Flag_CSAT_F", "O_officer_F"]
+];
+
+{
+    _x params ["_side", "_label", "_anchorMarker", "_flagClass", "_advisorClass"];
+
+    private _structure = [_side, true] call A3A_fnc_getCommandStructureForSide;
+    if !(typeName _structure isEqualTo "HASHMAP") then { continue };
+
+    private _spawnPos = markerPos _anchorMarker;
+    if (_spawnPos isEqualTo [0,0,0]) then { continue };
+
+    private _respawnMarker = _structure getOrDefault ["respawnMarker", ""];
+    if (_respawnMarker isEqualTo "") then {
+        _respawnMarker = format ["respawn_%1", toLower _label];
+    };
+
+    if !(_respawnMarker in allMapMarkers) then {
+        createMarker [_respawnMarker, _spawnPos];
+    };
+    _respawnMarker setMarkerAlpha 0;
+    _respawnMarker setMarkerPos _spawnPos;
+    _structure set ["respawnMarker", _respawnMarker];
+
+    private _hqMarker = _structure getOrDefault ["hqMarker", ""];
+    if (_hqMarker isEqualTo "") then {
+        _hqMarker = format ["%1_HQ", _label];
+    };
+    if !(_hqMarker in allMapMarkers) then {
+        createMarker [_hqMarker, _spawnPos];
+    };
+    _hqMarker setMarkerShape "ELLIPSE";
+    _hqMarker setMarkerSize [75,75];
+    _hqMarker setMarkerPos _spawnPos;
+    _structure set ["hqMarker", _hqMarker];
+
+    if (_structure getOrDefault ["hqGarrison", ""] isEqualTo "") then {
+        _structure set ["hqGarrison", _hqMarker];
+    };
+
+    private _garrison = A3A_garrison getOrDefault [_hqMarker, createHashMap];
+    if !(typeName _garrison isEqualTo "HASHMAP") then {
+        _garrison = createHashMap;
+    };
+    {
+        if (isNil {_garrison get _x}) then { _garrison set [_x, []]; };
+    } forEach ["troops", "vehicles", "buildings", "spawnedBuildings"];
+    A3A_garrison set [_hqMarker, _garrison];
+
+    _structure set ["hqPosition", _spawnPos];
+
+    private _hqObjects = _structure getOrDefault ["hqObjects", createHashMap];
+    if !(typeName _hqObjects isEqualTo "HASHMAP") then { _hqObjects = createHashMap; };
+
+    private _spawnStatic = {
+        params ["_existing", "_className"];
+        if !(isNull _existing) exitWith { _existing };
+        if (_className isEqualTo "") exitWith { objNull };
+        private _obj = createVehicle [_className, _spawnPos, [], 0, "CAN_COLLIDE"];
+        _obj allowDamage false;
+        _obj enableRopeAttach false;
+        _obj hideObjectGlobal true;
+        _obj
+    };
+
+    private _camp = [_hqObjects getOrDefault ["camp", objNull], "Land_TentSolar_01_olive_F"] call _spawnStatic;
+    private _crate = [_hqObjects getOrDefault ["crate", objNull], "IG_supplyCrate_F"] call _spawnStatic;
+    private _vehicleCrate = [_hqObjects getOrDefault ["vehicleCrate", objNull], "Land_CargoBox_V1_F"] call _spawnStatic;
+    private _mapBoard = [_hqObjects getOrDefault ["map", objNull], "MapBoard_seismic_F"] call _spawnStatic;
+    private _flag = [_hqObjects getOrDefault ["flag", objNull], _flagClass] call _spawnStatic;
+
+    private _advisor = _hqObjects getOrDefault ["advisor", objNull];
+    if (isNull _advisor && {!(_advisorClass isEqualTo "")}) then {
+        private _group = createGroup _side;
+        _advisor = _group createUnit [_advisorClass, _spawnPos, [], 0, "NONE"];
+        _advisor allowDamage false;
+        _advisor setBehaviour "SAFE";
+        _advisor disableAI "MOVE";
+        _advisor disableAI "AUTOTARGET";
+        group _advisor setGroupOwner 2;
+    };
+
+    _hqObjects set ["camp", _camp];
+    _hqObjects set ["crate", _crate];
+    _hqObjects set ["vehicleCrate", _vehicleCrate];
+    _hqObjects set ["map", _mapBoard];
+    _hqObjects set ["flag", _flag];
+    if !(isNull _advisor) then { _hqObjects set ["advisor", _advisor]; };
+
+    _structure set ["hqObjects", _hqObjects];
+    _structure set ["hqMoving", false];
+
+    [_spawnPos, _side] call A3A_fnc_relocateHQObjects;
+
+    [_respawnMarker, 1, _side] call A3A_fnc_setMarkerAlphaForSide;
+    {
+        if (_x == _side) then { continue };
+        [_respawnMarker, 0, _x] call A3A_fnc_setMarkerAlphaForSide;
+    } forEach [teamPlayer, Occupants, Invaders, resistance, civilian];
+
+    [_side, _structure] call A3A_fnc_setCommandStructureForSide;
+} forEach _hqDefinitions;
+
 missionNamespace setVariable ["A3A_civilWarMode", true, true];
 
 // Ensure an entry exists for the rebel AI side as well for save compatibility.

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -62,6 +62,18 @@ private _rebelEconomy = _rebelStructure getOrDefault ["economy", createHashMapFr
 _rebelEconomy set ["resources", initialFactionMoney];
 _rebelEconomy set ["hr", initialHr];
 _rebelStructure set ["economy", _rebelEconomy];
+_rebelStructure set ["respawnMarker", "respawnTeamPlayer"];
+_rebelStructure set ["hqMarker", "Synd_HQ"];
+_rebelStructure set ["hqGarrison", "Synd_HQ"];
+_rebelStructure set ["hqPosition", getMarkerPos "Synd_HQ"];
+_rebelStructure set ["hqObjects", createHashMapFromArray [
+    ["camp", fireX],
+    ["crate", boxX],
+    ["map", mapX],
+    ["vehicleCrate", vehicleBox],
+    ["flag", flagX],
+    ["advisor", petros]
+]];
 _commandStructures set [[teamPlayer] call A3A_fnc_sideToKey, _rebelStructure];
 DECLARE_SERVER_VAR(A3A_commandStructures, _commandStructures);
 DECLARE_SERVER_VAR(A3A_civilWarMode, false);


### PR DESCRIPTION
## Summary
- extend command structure defaults with HQ metadata and register rebel HQ objects
- parameterise HQ move/build/relocate logic to use the owning side's command structure data
- spawn NATO/CSAT HQ markers, garrisons, and support objects when Civil War mode initialises

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e326de1e64832fa5d2c52e07ed697b