### PR TITLE
Add side-aware commander handoff for Civil War factions

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -222,6 +222,7 @@ class CfgFunctions
             class getCommandStructureForSide {};
             class getCommanderForSide {};
             class getEconomyForSide {};
+            class registerCommanderActions {};
             class setCommandStructureForSide {};
             class setCommanderForSide {};
             class sideToKey {};

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -7,3 +7,24 @@
         <Polish>Wojna domowa (NATO vs CSAT)</Polish>
         <Chinesesimp>内战 (北约 vs CSAT)</Chinesesimp>
       </Key>
+      <Key ID="STR_A3A_commander_action_claim">
+        <Original>Claim %1 Command</Original>
+      </Key>
+      <Key ID="STR_A3A_commander_action_claim_generic">
+        <Original>Claim Command</Original>
+      </Key>
+      <Key ID="STR_A3A_commander_action_abdicate">
+        <Original>Abdicate %1 Command</Original>
+      </Key>
+      <Key ID="STR_A3A_commander_action_abdicate_generic">
+        <Original>Abdicate Command</Original>
+      </Key>
+      <Key ID="STR_A3A_commander_action_wrong_side">
+        <Original>Only %1 forces may interact with this HQ.</Original>
+      </Key>
+      <Key ID="STR_A3A_commander_action_wrong_side_generic">
+        <Original>Only authorised forces may interact with this HQ.</Original>
+      </Key>
+      <Key ID="STR_A3A_commander_action_not_commander">
+        <Original>Only the current commander may abdicate.</Original>
+      </Key>

--- a/A3A/addons/core/functions/Base/fn_onPlayerDisconnect.sqf
+++ b/A3A/addons/core/functions/Base/fn_onPlayerDisconnect.sqf
@@ -13,15 +13,16 @@ if (side _unit == sideLogic || {_uid == ""}) exitWith {
 // find original player unit in case of remote control
 private _realUnit = _unit getVariable ["owner", _unit];
 
-Debug_3("Player unit %1, original unit %2, boss %3", _unit, _realUnit, theBoss);
+private _currentCommander = [teamPlayer] call A3A_fnc_getCommanderForSide;
+Debug_3("Player unit %1, original unit %2, boss %3", _unit, _realUnit, _currentCommander);
 
-if (_realUnit == theBoss) then
+if (_realUnit == _currentCommander) then
 {
-	if (A3A_petrosMoving) then { call A3A_fnc_buildHQ };
+        if (A3A_petrosMoving) then { call A3A_fnc_buildHQ };
 
-	// Remove our real unit from boss
-	_realUnit setVariable ["eligible", false, true];
-	[] call A3A_fnc_assignBossIfNone;
+        // Remove our real unit from boss
+        _realUnit setVariable ["eligible", false, true];
+        [false, teamPlayer] call A3A_fnc_assignBossIfNone;
 };
 
 //Need to check the group's side, as player may be a civ. Unknown is in case they've been moved out of their group.

--- a/A3A/addons/core/functions/Command/fn_defaultCommandStructure.sqf
+++ b/A3A/addons/core/functions/Command/fn_defaultCommandStructure.sqf
@@ -21,7 +21,15 @@ if (_sideKey isEqualTo "") then {
 private _structure = createHashMap;
 _structure set ["sideKey", _sideKey];
 _structure set ["side", _sideInput];
+_structure set ["commanderLabel", _sideKey];
 _structure set ["commander", objNull];
+_structure set ["commanderHcGroups", []];
+_structure set ["commanderSyncObjects", []];
+_structure set ["commanderNotificationTarget", objNull];
+_structure set ["commanderNotificationChannel", "hint"];
+_structure set ["commanderNotificationTitle", ""];
+_structure set ["commanderStatisticsTargets", [teamPlayer, civilian]];
+_structure set ["commanderEligibilityVar", "eligible"];
 _structure set ["hqObjects", []];
 _structure set ["hqPosition", [0,0,0]];
 _structure set ["hqMarker", ""];

--- a/A3A/addons/core/functions/Command/fn_registerCommanderActions.sqf
+++ b/A3A/addons/core/functions/Command/fn_registerCommanderActions.sqf
@@ -1,0 +1,98 @@
+/*
+ * Author: ChatGPT
+ *
+ * Adds commander claim and abdicate actions to the provided HQ object.
+ */
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params [
+    ["_hqObject", objNull],
+    ["_sideInput", teamPlayer],
+    ["_label", ""]
+];
+
+if (isNull _hqObject) exitWith {};
+if (!hasInterface) exitWith {};
+
+private _structure = [_sideInput, false] call A3A_fnc_getCommandStructureForSide;
+private _side = _structure getOrDefault ["side", _sideInput];
+private _sideKey = _structure getOrDefault ["sideKey", [_sideInput] call A3A_fnc_sideToKey];
+
+private _existingNames = (actionIDs _hqObject) apply { (_hqObject actionParams _x)#0 };
+
+private _claimText = if (_label != "") then {
+    format [localize "STR_A3A_commander_action_claim", _label]
+} else {
+    localize "STR_A3A_commander_action_claim_generic"
+};
+
+if !(_claimText in _existingNames) then {
+    _hqObject addAction [
+        _claimText,
+        {
+            params ["_target", "_caller", "_actionId", "_args"];
+            _args params ["_side", "_label"];
+
+            if (!isPlayer _caller) exitWith {};
+            private _realCaller = _caller getVariable ["owner", _caller];
+            if (isNull _realCaller) exitWith {};
+
+            if (!(side group _realCaller isEqualTo _side)) exitWith {
+                private _message = if (_label != "") then {
+                    format [localize "STR_A3A_commander_action_wrong_side", _label]
+                } else {
+                    localize "STR_A3A_commander_action_wrong_side_generic"
+                };
+                [localize "STR_A3A_fn_orgp_tBTogEli_titel", _message] call A3A_fnc_customHint;
+            };
+
+            if !(_realCaller getVariable ["eligible", true]) exitWith {
+                [localize "STR_A3A_fn_orgp_tBTogEli_titel", localize "STR_A3A_fn_orgp_tBTogEli_eligible_no"] call A3A_fnc_customHint;
+            };
+
+            [_realCaller, _side] remoteExecCall ["A3A_fnc_makePlayerBossIfEligible", 2];
+        },
+        [_side, _label],
+        1.5,
+        true,
+        true,
+        "",
+        "isPlayer _this"
+    ];
+};
+
+private _abdicateText = if (_label != "") then {
+    format [localize "STR_A3A_commander_action_abdicate", _label]
+} else {
+    localize "STR_A3A_commander_action_abdicate_generic"
+};
+
+if !(_abdicateText in _existingNames) then {
+    _hqObject addAction [
+        _abdicateText,
+        {
+            params ["_target", "_caller", "_actionId", "_args"];
+            _args params ["_side", "_label"];
+
+            if (!isPlayer _caller) exitWith {};
+            private _realCaller = _caller getVariable ["owner", _caller];
+            if (isNull _realCaller) exitWith {};
+
+            private _commander = [_side] call A3A_fnc_getCommanderForSide;
+            if (_realCaller isNotEqualTo _commander) exitWith {
+                [localize "STR_A3A_fn_orgp_tBTogEli_titel", localize "STR_A3A_commander_action_not_commander"] call A3A_fnc_customHint;
+            };
+
+            [_side, objNull] remoteExecCall ["A3A_fnc_theBossTransfer", 2];
+        },
+        [_side, _label],
+        1.5,
+        true,
+        true,
+        "",
+        "isPlayer _this"
+    ];
+};
+
+Debug(format ["Commander actions registered for %1 on %2 (%3)", _hqObject, _sideKey, typeOf _hqObject]);

--- a/A3A/addons/core/functions/Command/fn_setCommanderForSide.sqf
+++ b/A3A/addons/core/functions/Command/fn_setCommanderForSide.sqf
@@ -27,4 +27,9 @@ private _currentCommander = _structure getOrDefault ["commander", objNull];
 if (_currentCommander isEqualTo _commander) exitWith { true };
 
 _structure set ["commander", _commander];
+private _registeredSide = _structure getOrDefault ["side", _sideInput];
+if (_registeredSide isEqualTo teamPlayer) then {
+    theBoss = _commander;
+    if (isServer) then { publicVariable "theBoss"; };
+};
 [_sideInput, _structure, _propagate] call A3A_fnc_setCommandStructureForSide

--- a/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
@@ -2,24 +2,25 @@
 FIX_LINE_NUMBERS()
 
 if !(isServer) exitWith { Error("Attempted to call server function as non-server") };
-params [["_memberForced", false]];
+params [["_memberForced", false], ["_sideInput", teamPlayer]];
 
 if (!isNil "A3A_electionInProgress") exitWith {};
 A3A_electionInProgress = true;
 
 
 // Don't run if a Boss exists and is still eligible & active
+private _currentCommander = [_sideInput] call A3A_fnc_getCommanderForSide;
 private _electionReason = call {
-    if (isNull theBoss) exitWith { "there is no boss" };
-    if (_memberForced && !([theBoss] call A3A_fnc_isMember)) exitWith { "the boss is a guest" };
-    if !(theBoss getVariable ["eligible", true]) exitWith { "the boss is not eligible" };
-    if (theBoss getVariable ["isAFK", false]) exitWith { "the boss is AFK" };
+    if (isNull _currentCommander) exitWith { "there is no boss" };
+    if (_memberForced && !([_currentCommander] call A3A_fnc_isMember)) exitWith { "the boss is a guest" };
+    if !(_currentCommander getVariable ["eligible", true]) exitWith { "the boss is not eligible" };
+    if (_currentCommander getVariable ["isAFK", false]) exitWith { "the boss is AFK" };
 };
 if (isNil "_electionReason") exitWith {
-    Debug_1("Not attempting to assign new boss - player %1 is the boss", name theBoss);
+    Debug_1("Not attempting to assign new boss - player %1 is the boss", name _currentCommander);
     A3A_electionInProgress = nil;
 };
-Info_2("Election triggered because %1. Previous boss was %2", _electionReason, name theBoss);
+Info_2("Election triggered because %1. Previous boss was %2", _electionReason, name _currentCommander);
 
 
 // Note: allPlayers doesn't work for a while after server startup, so this function isn't used for picking the initial commander
@@ -45,13 +46,13 @@ private _bossRank = 0;
 if (!isNull _nextBoss) then
 {
     Info_1("Player chosen for Boss: %1", name _nextBoss);
-    if (theBoss != _nextBoss) then { [_nextBoss] call A3A_fnc_theBossTransfer };
+    if (_currentCommander != _nextBoss) then { [_sideInput, _nextBoss] call A3A_fnc_theBossTransfer };
 }
 else
 {
     Info("Couldn't select a new boss - no eligible candidates.");
     // Remove current boss if any, as they're ineligible
-    if (!isNull theBoss) then { [] call A3A_fnc_theBossTransfer };
+    if (!isNull _currentCommander) then { [_sideInput, objNull] call A3A_fnc_theBossTransfer };
 };
 
 A3A_electionInProgress = nil;

--- a/A3A/addons/core/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
@@ -1,12 +1,40 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params ["_player"];
+params ["_player", ["_sideInput", teamPlayer]];
 
-Info_1("Attempting to make %1 the boss", name _player);
+if (isNull _player) exitWith {
+    Error("Attempted to promote a null player to commander");
+    false
+};
 
-if !(_player getVariable ["eligible", false]) exitWith { Error("Attempted boss transfer to an ineligible player"); false };
-if (!A3A_guestCommander and !(_player call A3A_fnc_isMember)) exitWith { Error("Attempted to transfer boss to a guest"); false };
+private _structure = [_sideInput, true] call A3A_fnc_getCommandStructureForSide;
+if (typeName _structure != "HASHMAP") exitWith { false };
 
-Info("Player is eligible, making them the boss");
-[_player] call A3A_fnc_theBossTransfer;
-true;
+private _side = _structure getOrDefault ["side", _sideInput];
+private _sideKey = _structure getOrDefault ["sideKey", [_sideInput] call A3A_fnc_sideToKey];
+
+private _eligibilityVar = _structure getOrDefault ["commanderEligibilityVar", "eligible"];
+private _defaultEligibility = if (_side isEqualTo teamPlayer) then { false } else { true };
+private _isEligible = _player getVariable [_eligibilityVar, _player getVariable ["eligible", _defaultEligibility]];
+if (!_isEligible) exitWith {
+    Error(format ["Attempted commander transfer for %1 on %2 without eligibility", name _player, _sideKey]);
+    false
+};
+
+// Only enforce guest restrictions for the rebel commander to maintain backwards compatibility.
+if (_side isEqualTo teamPlayer) then {
+    if (!A3A_guestCommander && !(_player call A3A_fnc_isMember)) exitWith {
+        Error(format ["Attempted to transfer rebel command to guest player %1", name _player]);
+        false
+    };
+};
+
+private _realSide = side group _player;
+if (!(_realSide isEqualTo _side)) exitWith {
+    Error(format ["Attempted commander transfer for %1 on %2 but player is on %3", name _player, _sideKey, _realSide]);
+    false
+};
+
+Info_2("Player %1 eligible for commander of %2", name _player, _sideKey);
+[_sideInput, _player] call A3A_fnc_theBossTransfer;
+true

--- a/A3A/addons/core/functions/OrgPlayers/fn_theBossToggleEligibility.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_theBossToggleEligibility.sqf
@@ -6,21 +6,23 @@ params ["_playerX", ["_newBoss", objNull]];
 // Find real player unit, in case of remote control
 _playerX = _playerX getVariable ["owner", _playerX];
 
+private _currentCommander = [teamPlayer] call A3A_fnc_getCommanderForSide;
+
 private _forceElection = false;
 private _text = "";
 if (_playerX getVariable ["eligible",false]) then
 {
 	_playerX setVariable ["eligible",false,true];
-	if (_playerX == theBoss) then
-	{
-		if(!isNull _newBoss && isPlayer _newBoss) then
-		{
-			if ([_newBoss] call A3A_fnc_makePlayerBossIfEligible) then {
-				_text = format [localize "STR_A3A_fn_orgp_tBTogEli_resign_choosing", name _newBoss];
-			}
-			else {
-				_text = format [localize "STR_A3A_fn_orgp_tBTogEli_resign_chosen", name _newBoss];
-			};
+        if (_playerX == _currentCommander) then
+        {
+                if(!isNull _newBoss && isPlayer _newBoss) then
+                {
+                        if ([_newBoss, teamPlayer] call A3A_fnc_makePlayerBossIfEligible) then {
+                                _text = format [localize "STR_A3A_fn_orgp_tBTogEli_resign_choosing", name _newBoss];
+                        }
+                        else {
+                                _text = format [localize "STR_A3A_fn_orgp_tBTogEli_resign_chosen", name _newBoss];
+                        };
 		}
 		else {
 			_text = localize "STR_A3A_fn_orgp_tBTogEli_resign_others";
@@ -28,20 +30,20 @@ if (_playerX getVariable ["eligible",false]) then
 	}
 	else
 	{
-		_text = localize "STR_A3A_fn_orgp_tBTogEli_eligible_no";
-	};
+                _text = localize "STR_A3A_fn_orgp_tBTogEli_eligible_no";
+        };
 }
 else
 {
-	if ([_playerX] call A3A_fnc_isMember) then { _forceElection = true };
-	_playerX setVariable ["eligible",true,true];
-	_text = localize "STR_A3A_fn_orgp_tBTogEli_eligible_yes";
+        if ([_playerX] call A3A_fnc_isMember) then { _forceElection = true };
+        _playerX setVariable ["eligible",true,true];
+        _text = localize "STR_A3A_fn_orgp_tBTogEli_eligible_yes";
 };
 
 
 [_titleStr, _text] remoteExec ["A3A_fnc_customHint", _playerX];
 
 // Will remove current boss if now ineligible
-[_forceElection] call A3A_fnc_assignBossIfNone;
+[_forceElection, teamPlayer] call A3A_fnc_assignBossIfNone;
 
 ["update"] remoteExecCall ["A3A_GUI_fnc_playerTab", _playerX];

--- a/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
@@ -1,64 +1,111 @@
-if !(isServer) exitWith {};
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params [["_newBoss", objNull], ["_silent", false]];
 
-if (!isNull theBoss) then
+if !(isServer) exitWith {};
+
+params [["_sideInput", teamPlayer], ["_newCommander", objNull], ["_silent", false]];
+
+private _structure = [_sideInput, true] call A3A_fnc_getCommandStructureForSide;
+if (typeName _structure != "HASHMAP") exitWith {};
+
+private _side = _structure getOrDefault ["side", _sideInput];
+private _sideKey = _structure getOrDefault ["sideKey", [_sideInput] call A3A_fnc_sideToKey];
+private _sideLabel = _structure getOrDefault ["commanderLabel", _sideKey];
+private _currentCommander = _structure getOrDefault ["commander", objNull];
+
+private _syncObjects = +(_structure getOrDefault ["commanderSyncObjects", []]);
+if (_syncObjects isEqualTo [] && {!isNil "HC_commanderX"} && {_side isEqualTo teamPlayer}) then {
+    _syncObjects = [HC_commanderX];
+    _structure set ["commanderSyncObjects", _syncObjects];
+};
+
+private _notificationTarget = _structure getOrDefault ["commanderNotificationTarget", objNull];
+if (isNull _notificationTarget && {!isNil "petros"} && {alive petros} && {_side isEqualTo teamPlayer}) then {
+    _notificationTarget = petros;
+    _structure set ["commanderNotificationTarget", petros];
+};
+
+private _notificationChannel = _structure getOrDefault ["commanderNotificationChannel", "hint"];
+private _notificationTitle = _structure getOrDefault ["commanderNotificationTitle", ""];
+if (_notificationTitle isEqualTo "") then {
+    _notificationTitle = localize "STR_A3A_fn_orgp_tBTransfer_newCommTitle";
+};
+
+private _statisticsTargets = _structure getOrDefault ["commanderStatisticsTargets", [_side, civilian]];
+
+private _transferGroups = [];
+if (!isNull _currentCommander) then {
+    Debug_2("Removing %1 as commander for %2", name _currentCommander, _sideLabel);
+    _transferGroups = hcAllGroups _currentCommander;
+    {
+        _currentCommander synchronizeObjectsRemove [_x];
+        _x synchronizeObjectsRemove [_currentCommander];
+    } forEach _syncObjects;
+    hcRemoveAllGroups _currentCommander;
+};
+_structure set ["commanderHcGroups", _transferGroups];
+
+[_sideInput, _newCommander, false] call A3A_fnc_setCommanderForSide;
+
+if (isNull _newCommander) then {
+    Debug_1("Commander position for %1 cleared", _sideLabel);
+    [_sideInput, _structure] call A3A_fnc_setCommandStructureForSide;
+
+    if (_silent) exitWith {};
+
+    [_notificationTarget, _notificationChannel, _notificationTitle, _statisticsTargets, _sideLabel] spawn {
+        params ["_commsTarget", "_channel", "_title", "_statsTargets", "_sideName"];
+        sleep 5;
+        private _text = format [localize "STR_A3A_fn_orgp_tBTransfer_noEligible", _sideName];
+        if (!isNull _commsTarget) then {
+            [_commsTarget, _channel, _text, _title] remoteExec ["A3A_fnc_commsMP", 0];
+        };
+        [] remoteExec ["A3A_fnc_statistics", _statsTargets];
+    };
+
+    exitWith {};
+};
+
+Debug_2("Assigning %1 as commander for %2", name _newCommander, _sideLabel);
+
+private _commanderGroup = group _newCommander;
+if (!isNull _commanderGroup) then {
+    [_commanderGroup, _newCommander] remoteExec ["selectLeader", groupOwner _commanderGroup];
+};
+
 {
-    Debug_1("Removing %1 from Boss roles.", name theBoss);
+    _newCommander synchronizeObjectsAdd [_x];
+    _x synchronizeObjectsAdd [_newCommander];
+} forEach _syncObjects;
 
-	bossHCGroupsTransfer = hcAllGroups theBoss;
-	hcRemoveAllGroups theBoss;
-
-	theBoss synchronizeObjectsRemove [HC_commanderX];
-	HC_commanderX synchronizeObjectsRemove [theBoss];
+private _previousGroups = _structure getOrDefault ["commanderHcGroups", []];
+if (_previousGroups isEqualTo []) then {
+    {
+        if ((leader _x getVariable ["spawner", false]) && {!isPlayer leader _x} && {side _x isEqualTo _side}) then {
+            _newCommander hcSetGroup [_x];
+            _x setGroupOwner owner _newCommander;
+        };
+    } forEach allGroups;
+} else {
+    {
+        if (!isNull _x && {alive leader _x} && {side _x isEqualTo _side}) then {
+            _newCommander hcSetGroup [_x];
+            _x setGroupOwner owner _newCommander;
+        };
+    } forEach _previousGroups;
 };
 
-theBoss = _newBoss;
-publicVariable "theBoss";
+_structure set ["commanderHcGroups", []];
+[_sideInput, _structure] call A3A_fnc_setCommandStructureForSide;
 
-if (isNull _newBoss) exitWith {
-	[_silent] spawn {
-		params ["_silent"];
-		sleep 5;
-		private _textX = format [localize "STR_A3A_fn_orgp_tBTransfer_noEligible"];
-		if (!_silent) then {[petros,"hint",_textX, localize "STR_A3A_fn_orgp_tBTransfer_newCommTitle"] remoteExec ["A3A_fnc_commsMP", 0]};
-		[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];
-	};
-};
+if (_silent) exitWith {};
 
-[group theBoss, theBoss] remoteExec ["selectLeader", groupOwner group theBoss];
-
-theBoss synchronizeObjectsAdd [HC_commanderX];
-HC_commanderX synchronizeObjectsAdd [theBoss];
-
-if (!isNil "bossHCGroupsTransfer") then
-{
-    Debug("Found previous HC groups, transferring.");
-	{
-		theBoss hcSetGroup [_x];
-		_x setGroupOwner owner theBoss;
-	} forEach bossHCGroupsTransfer;
-	bossHCGroupsTransfer = nil;
-}
-else {
-	// Boss got lost somewhere, try to find HC groups by scanning
-    Debug("No previous HC groups found, scanning all groups.");
-	{
-		if ((leader _x getVariable ["spawner",false]) and (!isPlayer leader _x) and (side _x == teamPlayer)) then
-		{
-			theBoss hcSetGroup [_x];
-			_x setGroupOwner owner theBoss;
-		};
-	} forEach allGroups;
-};
-
-Debug_1("New boss %1 set.", name theBoss);
-
-[_silent] spawn {
-	params ["_silent"];
-	sleep 5;
-	private _textX = format [localize "STR_A3A_fn_orgp_tBTransfer_newCommLong", name theBoss];
-	if (!_silent) then {[petros,"hint",_textX, localize "STR_A3A_fn_orgp_tBTransfer_newCommTitle"] remoteExec ["A3A_fnc_commsMP", 0]};
-	[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];
+[_notificationTarget, _notificationChannel, _notificationTitle, _statisticsTargets, _newCommander, _sideLabel] spawn {
+    params ["_commsTarget", "_channel", "_title", "_statsTargets", "_commander", "_sideName"];
+    sleep 5;
+    private _text = format [localize "STR_A3A_fn_orgp_tBTransfer_newCommLong", name _commander, _sideName];
+    if (!isNull _commsTarget) then {
+        [_commsTarget, _channel, _text, _title] remoteExec ["A3A_fnc_commsMP", 0];
+    };
+    [] remoteExec ["A3A_fnc_statistics", _statsTargets];
 };

--- a/A3A/addons/core/functions/init/fn_initCivilWarMode.sqf
+++ b/A3A/addons/core/functions/init/fn_initCivilWarMode.sqf
@@ -18,6 +18,7 @@ private _applyBaseline = toLower _startType == "new";
     private _side = _x#0;
     private _label = _x#1;
     private _structure = [_side, true] call A3A_fnc_getCommandStructureForSide;
+    _structure set ["commanderLabel", _label];
     private _economy = _structure getOrDefault ["economy", createHashMapFromArray [["resources", 0], ["hr", 0], ["storage", createHashMap]]];
 
     private _currentResources = _economy getOrDefault ["resources", 0];
@@ -29,6 +30,42 @@ private _applyBaseline = toLower _startType == "new";
     private _deltaHr = _targetHr - _currentHr;
 
     [_side, _deltaResources, _deltaHr, true] call A3A_fnc_updateEconomyForSide;
+
+    _structure set ["commanderStatisticsTargets", [_side, civilian]];
+    _structure set ["commanderNotificationTitle", localize "STR_A3A_fn_orgp_tBTransfer_newCommTitle"];
+    _structure set ["commanderNotificationTarget", objNull];
+
+    private _defaultMarker = if (_side isEqualTo Occupants) then {"NATO_carrier"} else {"CSAT_carrier"};
+    _structure set ["hqMarker", _structure getOrDefault ["hqMarker", _defaultMarker]];
+
+    private _hqObjects = _structure getOrDefault ["hqObjects", []];
+    if (_hqObjects isEqualTo []) then {
+        private _markerPos = markerPos (_structure get "hqMarker");
+        if !(_markerPos isEqualTo [0,0,0]) then {
+            private _searchClasses = [
+                "Land_Cargo_HQ_V1_F",
+                "Land_Cargo_HQ_V2_F",
+                "Land_Cargo_HQ_V3_F",
+                "Land_Cargo_Tower_V1_F",
+                "FlagPole_F",
+                "Flag_NATO_F",
+                "Flag_CSAT_F"
+            ];
+            private _candidates = nearestObjects [_markerPos, _searchClasses, 125];
+            if !(_candidates isEqualTo []) then {
+                _hqObjects = [_candidates#0];
+                _structure set ["hqObjects", _hqObjects];
+            };
+        };
+    };
+
+    [_side, _structure] call A3A_fnc_setCommandStructureForSide;
+
+    {
+        if (!isNull _x) then {
+            [_x, _side, _label] remoteExec ["A3A_fnc_registerCommanderActions", 0, _x];
+        };
+    } forEach (_structure getOrDefault ["hqObjects", []]);
 
     Info_5("Civil War economy baseline applied to %1: res %2 -> %3, hr %4 -> %5", _label, _currentResources, _targetResources, _currentHr, _targetHr);
 } forEach [

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -242,7 +242,7 @@ if !(isPlayer leader group player) then {
     [group player, player] remoteExec ["selectLeader", groupOwner group player];
 };
 
-[] remoteExecCall ["A3A_fnc_assignBossIfNone", 2];
+[false, teamPlayer] remoteExecCall ["A3A_fnc_assignBossIfNone", 2];
 
 
 if (isServer || player isEqualTo theBoss || (call BIS_fnc_admin) > 0) then {  // Local Host || Commander || Dedicated Admin

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -82,11 +82,11 @@ while {true} do
         _x set [4, 0.5 max _r min 1.0];
     } forEach A3A_supportMarkerTypes;
 */
-	if (isMultiplayer) then
-	{
-		[] spawn A3A_fnc_promotePlayer;
-		[] call A3A_fnc_assignBossIfNone;
-	};
+        if (isMultiplayer) then
+        {
+                [] spawn A3A_fnc_promotePlayer;
+                [false, teamPlayer] call A3A_fnc_assignBossIfNone;
+        };
 
 	// Clear out plank objects that haven't been constructed and have exceeded the timeout
 	call A3A_fnc_processBuildingTimeouts;

--- a/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
+++ b/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
@@ -72,10 +72,11 @@ if (side group player == teamPlayer) then
 	//if (!A3A_hasACEMedical) then {[_newUnit] call A3A_fnc_initRevive};
 	disableUserInput false;
 	//_newUnit enableSimulation true;
-	if (_oldUnit == theBoss) then
-		{
-		[_newUnit, true] remoteExec ["A3A_fnc_theBossTransfer", 2];
-		};
+        private _currentCommander = [teamPlayer] call A3A_fnc_getCommanderForSide;
+        if (_oldUnit == _currentCommander) then
+                {
+                [teamPlayer, _newUnit, true] remoteExec ["A3A_fnc_theBossTransfer", 2];
+                };
 	//Give them a map, in case they're commander and need to replace petros.
 	_newUnit setUnitLoadout [[],[],[],[selectRandom ((A3A_faction_civ get "uniforms") + (A3A_faction_reb get "uniforms")), []],[],[],[],"",[],
 	[(selectRandom unlockedmaps),"","",(selectRandom unlockedCompasses),(selectRandom unlockedwatches),""]];


### PR DESCRIPTION
## Summary
- generalize commander promotion and transfer helpers to operate on a given side, persisting per-side HC sync data and notifications
- register claim/abdicate actions on Civil War HQ objects using the new commander-action helper
- update respawn and disconnect flows to resolve commanders through the side-aware lookup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e326e7f980832f86d8d7d83fd654a9