### PR TITLE
Persist command structures through saves

### DIFF
--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -41,6 +41,158 @@ if (isServer) then {
 	["rebelLoadouts"] call A3A_fnc_getStatVariable;
 	["jna_datalist"] call A3A_fnc_getStatVariable;
 	["minorSites"] call A3A_fnc_getStatVariable;
+	// Restore command structure state and per-side economies
+	private _commandStructureBlob = "commandStructures" call A3A_fnc_returnSavedStat;
+	private _loadedStructures = createHashMap;
+	private _commandStructureData = createHashMap;
+	if (_commandStructureBlob isEqualType createHashMap) then {
+		_commandStructureData = _commandStructureBlob getOrDefault ["structures", createHashMap];
+		if !(_commandStructureData isEqualType createHashMap) then { _commandStructureData = createHashMap };
+	};
+
+	{
+		private _sideKey = _x;
+		private _savedEntry = _y;
+		if !(typeName _savedEntry == "HASHMAP") then { continue };
+
+		private _sideValue = _savedEntry getOrDefault ["side", _sideKey];
+		private _structure = [_sideValue] call A3A_fnc_defaultCommandStructure;
+		private _structureSideKey = _structure getOrDefault ["sideKey", _sideKey];
+		if !(_structureSideKey isEqualTo _sideKey) then { _structure set ["sideKey", _sideKey] };
+
+		_structure set ["hqMarker", _savedEntry getOrDefault ["hqMarker", _structure getOrDefault ["hqMarker", ""]]];
+		_structure set ["hqPosition", +(_savedEntry getOrDefault ["hqPosition", _structure getOrDefault ["hqPosition", [0,0,0]]])];
+
+		private _hqObjects = [];
+		{
+			if !(_x isEqualType "") then { continue };
+			private _obj = objectFromNetId _x;
+			if (isNull _obj) then { continue };
+			_hqObjects pushBackUnique _obj;
+		} forEach (_savedEntry getOrDefault ["hqObjects", []]);
+		_structure set ["hqObjects", _hqObjects];
+
+		private _economyData = _savedEntry getOrDefault ["economy", createHashMap];
+		private _economy = _structure getOrDefault ["economy", createHashMapFromArray [["resources", 0], ["hr", 0], ["storage", createHashMap]]];
+		if (_economyData isEqualType createHashMap) then {
+			_economy set ["resources", _economyData getOrDefault ["resources", _economy getOrDefault ["resources", 0]]];
+			_economy set ["hr", _economyData getOrDefault ["hr", _economy getOrDefault ["hr", 0]]];
+			private _storageData = _economyData getOrDefault ["storage", _economy getOrDefault ["storage", createHashMap]];
+			if (_storageData isEqualType createHashMap) then {
+				_economy set ["storage", _storageData];
+			} else {
+				_economy set ["storage", createHashMap];
+			};
+		} else {
+			if (_economyData isEqualType []) then {
+				_economy set ["resources", _economyData param [0, _economy getOrDefault ["resources", 0]]];
+				_economy set ["hr", _economyData param [1, _economy getOrDefault ["hr", 0]]];
+			} else {
+				_economy set ["resources", _economy getOrDefault ["resources", 0]];
+				_economy set ["hr", _economy getOrDefault ["hr", 0]];
+			};
+			_economy set ["storage", createHashMap];
+		};
+		_structure set ["economy", _economy];
+
+		private _unlockState = _savedEntry getOrDefault ["unlockState", _structure getOrDefault ["unlockState", createHashMap]];
+		if (_unlockState isEqualType createHashMap) then {
+			private _unlockCopy = createHashMap;
+			{ _unlockCopy set [_x, _unlockState get _x] } forEach keys _unlockState;
+			_structure set ["unlockState", _unlockCopy];
+		} else {
+			_structure set ["unlockState", createHashMap];
+		};
+
+		private _logisticsQueue = _savedEntry getOrDefault ["logisticsQueue", []];
+		if (_logisticsQueue isEqualType []) then { _structure set ["logisticsQueue", +_logisticsQueue] } else { _structure set ["logisticsQueue", _structure getOrDefault ["logisticsQueue", []]] };
+
+		private _commanderData = _savedEntry getOrDefault ["commander", createHashMap];
+		private _commanderUID = "";
+		private _commander = objNull;
+		if (_commanderData isEqualType createHashMap) then {
+			_commanderUID = _commanderData getOrDefault ["uid", ""];
+			private _commanderNetId = _commanderData getOrDefault ["netId", ""];
+			if !(_commanderNetId isEqualTo "") then { _commander = objectFromNetId _commanderNetId };
+			if (isNull _commander && !(_commanderUID isEqualTo "")) then {
+				{ if (getPlayerUID _x == _commanderUID) exitWith { _commander = _x } } forEach (allPlayers - entities "HeadlessClient_F");
+			};
+		};
+		_structure set ["commander", _commander];
+		_structure set ["commanderUID", _commanderUID];
+
+		_loadedStructures set [_sideKey, _structure];
+	} forEach _commandStructureData;
+
+	private _requiredSides = [
+		[teamPlayer, [teamPlayer] call A3A_fnc_sideToKey],
+		[Occupants, [Occupants] call A3A_fnc_sideToKey],
+		[Invaders, [Invaders] call A3A_fnc_sideToKey]
+	];
+	{
+		_x params ["_side", "_sideKey"];
+		if (_sideKey isEqualTo "") then { continue };
+		if (isNil {_loadedStructures get _sideKey}) then {
+			private _structure = [_side] call A3A_fnc_defaultCommandStructure;
+			if (_sideKey isEqualTo ([teamPlayer] call A3A_fnc_sideToKey)) then {
+				private _economy = _structure getOrDefault ["economy", createHashMap];
+				_economy set ["resources", server getVariable ["resourcesFIA", initialFactionMoney]];
+				_economy set ["hr", server getVariable ["hr", initialHr]];
+				_structure set ["economy", _economy];
+			};
+			_loadedStructures set [_sideKey, _structure];
+		};
+	} forEach _requiredSides;
+
+	missionNamespace setVariable ["A3A_commandStructures", _loadedStructures];
+	if (isMultiplayer) then { publicVariable "A3A_commandStructures" };
+
+	{
+		private _sideKey = _x;
+		private _structure = _y;
+		private _economy = _structure getOrDefault ["economy", createHashMap];
+		private _resources = _economy getOrDefault ["resources", 0];
+		private _hr = _economy getOrDefault ["hr", 0];
+		private _resVar = format ["A3A_resources_%1", _sideKey];
+		private _hrVar = format ["A3A_hr_%1", _sideKey];
+		missionNamespace setVariable [_resVar, _resources];
+		missionNamespace setVariable [_hrVar, _hr];
+		if (isMultiplayer) then { publicVariable _resVar; publicVariable _hrVar; };
+		if (_sideKey isEqualTo ([teamPlayer] call A3A_fnc_sideToKey)) then {
+			server setVariable ["resourcesFIA", _resources, true];
+			server setVariable ["hr", _hr, true];
+		};
+	} forEach _loadedStructures;
+
+	private _rebelKey = [teamPlayer] call A3A_fnc_sideToKey;
+	private _rebelStructure = _loadedStructures getOrDefault [_rebelKey, createHashMap];
+	private _savedCommander = _rebelStructure getOrDefault ["commander", objNull];
+	if (isNull _savedCommander) then {
+		private _savedUID = _rebelStructure getOrDefault ["commanderUID", ""];
+		if !(_savedUID isEqualTo "") then {
+			{ if (getPlayerUID _x == _savedUID) exitWith { _savedCommander = _x } } forEach (allPlayers - entities "HeadlessClient_F");
+		};
+	};
+
+	if (!isNull _savedCommander && {theBoss != _savedCommander}) then {
+		[_savedCommander, true] call A3A_fnc_theBossTransfer;
+	} else {
+		if (isNull theBoss) then { [] call A3A_fnc_assignBossIfNone };
+	};
+
+	private _finalCommander = theBoss;
+	if (isNull _finalCommander) then {
+		_finalCommander = _rebelStructure getOrDefault ["commander", objNull];
+	};
+	private _finalCommanderUID = "";
+	if (!isNull _finalCommander) then {
+		_finalCommanderUID = _finalCommander getVariable ["A3A_playerUID", getPlayerUID _finalCommander];
+	};
+	_rebelStructure set ["commander", _finalCommander];
+	_rebelStructure set ["commanderUID", _finalCommanderUID];
+	_loadedStructures set [_rebelKey, _rebelStructure];
+	missionNamespace setVariable ["A3A_commandStructures", _loadedStructures];
+	if (isMultiplayer) then { publicVariable "A3A_commandStructures" };
 	//===========================================================================
 
 	//RESTORE THE STATE OF THE 'UNLOCKED' VARIABLES USING JNA_DATALIST

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -60,6 +60,87 @@ private _destroyedPositions = destroyedBuildings apply { getPosATL _x };
 ["radioKeys", [occRadioKeys,invRadioKeys]] call A3A_fnc_setStatVariable;
 ["HQKnowledge", [A3A_curHQInfoOcc, A3A_curHQInfoInv, A3A_oldHQInfoOcc, A3A_oldHQInfoInv]] call A3A_fnc_setStatVariable;
 
+// Persist command structure state for each faction
+private _commandStructures = missionNamespace getVariable ["A3A_commandStructures", createHashMap];
+private _savedCommandStructures = createHashMap;
+{
+	private _sideKey = _x;
+	private _structure = _y;
+	if !(typeName _structure == "HASHMAP") then { continue };
+
+	private _savedEntry = createHashMap;
+	private _structureSide = _structure getOrDefault ["side", _sideKey];
+	private _structureSideKey = [_structureSide] call A3A_fnc_sideToKey;
+	if (_structureSideKey isEqualTo "") then {
+		if (_structureSide isEqualType "") then { _structureSideKey = toLower _structureSide } else { _structureSideKey = _structure getOrDefault ["sideKey", _sideKey] };
+	};
+	_savedEntry set ["sideKey", _structure getOrDefault ["sideKey", _sideKey]];
+	_savedEntry set ["side", _structureSideKey];
+
+	private _commander = _structure getOrDefault ["commander", objNull];
+	private _commanderData = createHashMap;
+	if (!isNull _commander) then {
+		private _commanderUID = _commander getVariable ["A3A_playerUID", getPlayerUID _commander];
+		private _commanderNetId = netId _commander;
+		if !(_commanderUID isEqualTo "") then { _commanderData set ["uid", _commanderUID] };
+		if !(_commanderNetId isEqualTo "") then { _commanderData set ["netId", _commanderNetId] };
+	};
+	_savedEntry set ["commander", _commanderData];
+
+	private _hqMarker = _structure getOrDefault ["hqMarker", ""];
+	private _hqPosition = _structure getOrDefault ["hqPosition", [0,0,0]];
+	private _hqObjects = _structure getOrDefault ["hqObjects", []];
+	private _hqObjectNetIds = [];
+	{
+		if (isNull _x) then { continue };
+		private _netId = netId _x;
+		if (_netId isEqualTo "") then { continue };
+		_hqObjectNetIds pushBackUnique _netId;
+	} forEach _hqObjects;
+	_savedEntry set ["hqMarker", _hqMarker];
+	_savedEntry set ["hqPosition", +_hqPosition];
+	_savedEntry set ["hqObjects", _hqObjectNetIds];
+
+	private _economy = _structure getOrDefault ["economy", createHashMap];
+	private _savedEconomy = createHashMap;
+	_savedEconomy set ["resources", _economy getOrDefault ["resources", 0]];
+	_savedEconomy set ["hr", _economy getOrDefault ["hr", 0]];
+	private _storage = _economy getOrDefault ["storage", createHashMap];
+	if (_storage isEqualType createHashMap) then {
+		private _storageCopy = createHashMap;
+		{ _storageCopy set [_x, _storage get _x] } forEach keys _storage;
+		_savedEconomy set ["storage", _storageCopy];
+	} else {
+		_savedEconomy set ["storage", _storage];
+	};
+	_savedEntry set ["economy", _savedEconomy];
+
+	private _unlockState = _structure getOrDefault ["unlockState", createHashMap];
+	if (_unlockState isEqualType createHashMap) then {
+		private _unlockCopy = createHashMap;
+		{ _unlockCopy set [_x, _unlockState get _x] } forEach keys _unlockState;
+		_savedEntry set ["unlockState", _unlockCopy];
+	} else {
+		_savedEntry set ["unlockState", _unlockState];
+	};
+
+	private _logisticsQueue = _structure getOrDefault ["logisticsQueue", []];
+	if (_logisticsQueue isEqualType []) then {
+		_savedEntry set ["logisticsQueue", +_logisticsQueue];
+	} else {
+		_savedEntry set ["logisticsQueue", _logisticsQueue];
+	};
+
+	_savedCommandStructures set [_sideKey, _savedEntry];
+} forEach _commandStructures;
+
+private _commandStructureBlob = createHashMapFromArray [
+	["version", 1],
+	["structures", _savedCommandStructures]
+];
+["commandStructures", _commandStructureBlob] call A3A_fnc_setStatVariable;
+
+
 // Convert side values because JSON doesn't support them
 private _modifiedSites = createHashMap;
 private _sideToStr = createHashMapFromArray [[teamPlayer,0], [Occupants,1],	[Invaders,2]];


### PR DESCRIPTION
## Summary
- capture the current A3A_commandStructures state (commanders, HQ metadata, and economy data) when saving games
- load the serialized command structure blob on server start, rebuilding per-side missionNamespace data and updating commander ownership
- fall back to default command structures for legacy saves while keeping rebel economy values in sync

## Testing
- not run (script changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e326eaa6fc832fa5b9c87f5916d66f